### PR TITLE
increase buffer size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,7 @@ async fn serprog_task(mut class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiRe
     let mut led = Output::new(r.led, Level::Low);
     let mut buf = [0; 64];
 
-    const MAX_BUFFER_SIZE: usize = 256;
+    const MAX_BUFFER_SIZE: usize = 2048;
 
     loop {
         class.wait_connection().await;


### PR DESCRIPTION
After some benchmarking it looks like reading speed flattens out at 2K.

Benchmark results at 12M freq for a W25Q128:
buffer size - read time in s
256           43.85
512           39.09
1024          36.92
2024          35.89
4096          35.35
8192          35.12