### PR TITLE
Add missing build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Before you can compile and use Picoprog, you need to install the following depen
 - Install flip-link and elf2uf2
 
 ```sh
-sudo apt install libudev-dev
+sudo apt install build-essential libudev-dev pkg-config
 cargo install flip-link elf2uf2-rs
 ```
 


### PR DESCRIPTION
The project README includes a list of commands for Ubuntu/Debian
systems which are prequisites for building the Picoprog firmware.
On a fresh install of Ubuntu, these are however not enough.

This commit adds two more utilities required for a successful build.
