### PR TITLE
chore: bump all deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
@@ -76,18 +76,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitfield"
@@ -269,27 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +286,10 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "embassy-futures",
+ "embassy-hal-internal",
  "embassy-sync",
  "embassy-time",
  "embedded-hal 0.2.7",
@@ -323,7 +303,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -334,7 +314,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -345,12 +325,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -360,12 +340,12 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -375,7 +355,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -402,7 +382,6 @@ dependencies = [
  "fixed",
  "nb 1.1.0",
  "pio",
- "pio-proc",
  "rand_core",
  "rp-pac",
  "rp2040-boot2",
@@ -413,7 +392,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -426,7 +405,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -441,7 +420,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "document-features",
 ]
@@ -449,7 +428,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "embassy-executor",
  "heapless",
@@ -458,7 +437,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver-channel",
@@ -472,12 +451,12 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 
 [[package]]
 name = "embassy-usb-logger"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=556cc57c1fdc9eba0703ccc2281d39462d2d2c38#556cc57c1fdc9eba0703ccc2281d39462d2d2c38"
+source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
  "embassy-futures",
  "embassy-sync",
@@ -585,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -633,17 +612,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -693,6 +661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -728,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e56f323e2d610628d1f5bdd39168a774674ac7989ed67011963bb3f71edd797"
+checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -750,11 +727,12 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108dc8f5dabad92c65a03523055577d847f5dcc00f3e7d3a68bc4d48e01d8fe1"
+checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
 dependencies = [
  "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
@@ -762,16 +740,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "litrs"
@@ -791,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -888,9 +856,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -949,7 +917,16 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pio"
 version = "0.2.1"
-source = "git+https://github.com/rp-rs/pio-rs?rev=fa586448b0b223217eec8c92c19fe6823dd04cc4#fa586448b0b223217eec8c92c19fe6823dd04cc4"
+source = "git+https://github.com/rp-rs/pio-rs?rev=506a51b9bc135845e8544a0debd75847b73754dc#506a51b9bc135845e8544a0debd75847b73754dc"
+dependencies = [
+ "pio-core",
+ "pio-proc",
+]
+
+[[package]]
+name = "pio-core"
+version = "0.2.2"
+source = "git+https://github.com/rp-rs/pio-rs?rev=506a51b9bc135845e8544a0debd75847b73754dc#506a51b9bc135845e8544a0debd75847b73754dc"
 dependencies = [
  "arrayvec",
  "num_enum",
@@ -959,21 +936,21 @@ dependencies = [
 [[package]]
 name = "pio-parser"
 version = "0.2.2"
-source = "git+https://github.com/rp-rs/pio-rs?rev=fa586448b0b223217eec8c92c19fe6823dd04cc4#fa586448b0b223217eec8c92c19fe6823dd04cc4"
+source = "git+https://github.com/rp-rs/pio-rs?rev=506a51b9bc135845e8544a0debd75847b73754dc#506a51b9bc135845e8544a0debd75847b73754dc"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
- "pio",
+ "pio-core",
 ]
 
 [[package]]
 name = "pio-proc"
 version = "0.2.2"
-source = "git+https://github.com/rp-rs/pio-rs?rev=fa586448b0b223217eec8c92c19fe6823dd04cc4#fa586448b0b223217eec8c92c19fe6823dd04cc4"
+source = "git+https://github.com/rp-rs/pio-rs?rev=506a51b9bc135845e8544a0debd75847b73754dc#506a51b9bc135845e8544a0debd75847b73754dc"
 dependencies = [
  "codespan-reporting",
  "lalrpop-util",
- "pio",
+ "pio-core",
  "pio-parser",
  "proc-macro-error2",
  "proc-macro2",
@@ -1049,17 +1026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -1310,13 +1276,12 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "a3bb6001afcea98122260987f8b7b5da969ecad46dbf0b5453702f776b491a41"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "home",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1326,26 +1291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -1490,41 +1435,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ embassy-sync = "0.6.2"
 embassy-time = "0.4.0"
 embassy-usb = { version = "0.4.0", features = ["max-handler-count-6", "max-interface-count-6"] }
 embassy-usb-logger = "0.4.0"
-futures = { version = "0.3.30", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
+futures = { version = "0.3.31", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
 heapless = { version = "0.8.0", features = ["portable-atomic-critical-section", "ufmt"] }
-log = "0.4.22"
-portable-atomic = { version = "1.6.0", features = ["critical-section"] }
+log = "0.4.26"
+portable-atomic = { version = "1.11.0", features = ["critical-section"] }
 static_cell = "2.1.0"
 ufmt = "0.2.0"
 zerocopy = { version = "0.8", features = ["derive"] }
@@ -30,13 +30,13 @@ tock-registers = "0.9.0"
 num_enum = { version = "0.7.3", default-features = false }
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
-embassy-usb-logger = { git = "https://github.com/embassy-rs/embassy", rev = "556cc57c1fdc9eba0703ccc2281d39462d2d2c38" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
+embassy-usb-logger = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
 
 [profile.release]
 debug = true


### PR DESCRIPTION
This updates embassy and all the other crates with updates to their latest version. This supersedes #29 as embassy-rp 0.3.1 seems to have an issue with embassy-time 0.4.0 