### PR TITLE
Replace log crate with defmt

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,6 @@ target = "thumbv6m-none-eabi"
 [unstable]
 build-std = ["core"]
 build-std-features = ["panic_immediate_abort"]
+
+[env]
+DEFMT_LOG = "debug"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,10 +575,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "futures-sink"
@@ -598,10 +651,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -814,6 +873,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -895,8 +955,10 @@ dependencies = [
  "embassy-usb-logger",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "futures",
  "heapless",
  "log",
+ "portable-atomic",
  "serprog",
  "static_cell",
  "ufmt",
@@ -960,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 dependencies = [
  "critical-section",
 ]
@@ -972,6 +1034,15 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -1160,7 +1231,7 @@ dependencies = [
  "log",
  "num_enum",
  "tock-registers",
- "zerocopy 0.8.17",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -1184,6 +1255,15 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1298,6 +1378,23 @@ name = "tock-registers"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "typenum"
@@ -1526,6 +1623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,11 +1642,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
 dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -1556,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
@@ -259,6 +265,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
+name = "defmt"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f6162c53f659f65d00619fe31f14556a6e9f8752ccc4a41bd177ffcf3d6130"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d135dd939bad62d7490b0002602d35b358dce5fd9233a709d3c1ef467d4bde6"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3983b127f13995e68c1e29071e5d115cd96f215ccb5e6812e3728cd6f92653b3"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab697b3dbbc1750b7c8b821aa6f6e7f2480b47a99bc057a2ed7b170ebef0c51"
+dependencies = [
+ "critical-section",
+ "defmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +355,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea
 dependencies = [
  "cortex-m",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-executor-macros",
 ]
@@ -334,6 +383,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea
 dependencies = [
  "cortex-m",
  "critical-section",
+ "defmt",
  "num-traits",
 ]
 
@@ -362,6 +412,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
@@ -396,6 +447,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt",
  "embedded-io-async",
  "futures-sink",
  "futures-util",
@@ -409,6 +461,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-time-driver",
  "embedded-hal 0.2.7",
@@ -439,6 +492,7 @@ name = "embassy-usb"
 version = "0.4.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
+ "defmt",
  "embassy-futures",
  "embassy-net-driver-channel",
  "embassy-sync",
@@ -452,16 +506,8 @@ dependencies = [
 name = "embassy-usb-driver"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
-
-[[package]]
-name = "embassy-usb-logger"
-version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=17301c00e986c5b8536435ea31ebf5aaf13aed17#17301c00e986c5b8536435ea31ebf5aaf13aed17"
 dependencies = [
- "embassy-futures",
- "embassy-sync",
- "embassy-usb",
- "log",
+ "defmt",
 ]
 
 [[package]]
@@ -479,6 +525,9 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embedded-hal-async"
@@ -486,6 +535,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "defmt",
  "embedded-hal 1.0.0",
 ]
 
@@ -582,7 +632,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -604,17 +653,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -651,16 +689,12 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -873,7 +907,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -884,6 +917,16 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "panic-probe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4047d9235d1423d66cc97da7d07eddb54d4f154d6c13805c6d0793956f4f25b0"
+dependencies = [
+ "cortex-m",
+ "defmt",
+]
 
 [[package]]
 name = "parking_lot"
@@ -946,18 +989,19 @@ dependencies = [
  "assign-resources",
  "cortex-m",
  "cortex-m-rt",
+ "defmt",
+ "defmt-rtt",
  "embassy-executor",
  "embassy-futures",
  "embassy-rp",
  "embassy-sync",
  "embassy-time",
  "embassy-usb",
- "embassy-usb-logger",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures",
  "heapless",
- "log",
+ "panic-probe",
  "portable-atomic",
  "serprog",
  "static_cell",
@@ -1036,15 +1080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1131,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1225,10 +1260,11 @@ dependencies = [
 name = "serprog"
 version = "0.1.0"
 dependencies = [
+ "defmt",
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "log",
+ "futures",
  "num_enum",
  "tock-registers",
  "zerocopy 0.8.21",
@@ -1255,15 +1291,6 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "smallvec"
@@ -1374,27 +1401,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "tock-registers"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
 
 [[package]]
 name = "typenum"
@@ -1621,15 +1651,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,27 +7,27 @@ resolver = "2"
 
 [workspace.dependencies]
 assign-resources = "0.4.1"
-cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section"] }
+cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
-embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "nightly"] }
+embassy-executor = "0.7.0"
 embassy-futures = "0.1.1"
-embedded-hal = "1.0.0"
-embedded-hal-async = "1.0.0"
-serprog = { path = "./serprog" }
-embassy-rp = { version = "0.3.0", features = ["unstable-pac", "time-driver", "critical-section-impl", "rom-func-cache", "rom-v2-intrinsics", "rp2040"] }
+embassy-rp = "0.3.0"
 embassy-sync = "0.6.2"
 embassy-time = "0.4.0"
-embassy-usb = { version = "0.4.0", features = ["max-handler-count-6", "max-interface-count-6"] }
+embassy-usb = "0.4.0"
 embassy-usb-logger = "0.4.0"
-futures = { version = "0.3.31", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
-heapless = { version = "0.8.0", features = ["portable-atomic-critical-section", "ufmt"] }
+embedded-hal = "1.0.0"
+embedded-hal-async = "1.0.0"
+futures = { version = "0.3.31", default-features = false }
+heapless = "0.8.0"
 log = "0.4.26"
-portable-atomic = { version = "1.11.0", features = ["critical-section"] }
-static_cell = "2.1.0"
-ufmt = "0.2.0"
-zerocopy = { version = "0.8", features = ["derive"] }
-tock-registers = "0.9.0"
 num_enum = { version = "0.7.3", default-features = false }
+portable-atomic = "1.11.0"
+serprog = { path = "./serprog" }
+static_cell = "2.1.0"
+tock-registers = "0.9.0"
+ufmt = "0.2.0"
+zerocopy = "0.8.21"
 
 [patch.crates-io]
 embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,20 @@ resolver = "2"
 assign-resources = "0.4.1"
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
+defmt = "0.3.10"
+defmt-rtt = "0.4.1"
 embassy-executor = "0.7.0"
 embassy-futures = "0.1.1"
 embassy-rp = "0.3.0"
 embassy-sync = "0.6.2"
 embassy-time = "0.4.0"
 embassy-usb = "0.4.0"
-embassy-usb-logger = "0.4.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 futures = { version = "0.3.31", default-features = false }
 heapless = "0.8.0"
-log = "0.4.26"
 num_enum = { version = "0.7.3", default-features = false }
+panic-probe = "0.3.2"
 portable-atomic = "1.11.0"
 serprog = { path = "./serprog" }
 static_cell = "2.1.0"
@@ -36,7 +37,6 @@ embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e98
 embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
 embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
-embassy-usb-logger = { git = "https://github.com/embassy-rs/embassy", rev = "17301c00e986c5b8536435ea31ebf5aaf13aed17" }
 
 [profile.release]
 debug = true

--- a/picoprog/Cargo.toml
+++ b/picoprog/Cargo.toml
@@ -7,19 +7,21 @@ authors = ["Marvin Drees <marvin.drees@9elements.com>"]
 
 [dependencies]
 assign-resources.workspace = true
-cortex-m = { workspace = true, features = ["inline-asm", "critical-section"] }
+cortex-m = { workspace = true, features = ["critical-section", "inline-asm"] }
 cortex-m-rt.workspace = true
-embassy-executor = { workspace = true, features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "nightly"] }
+embassy-executor = { workspace = true, features = ["arch-cortex-m", "executor-interrupt", "executor-thread", "nightly"] }
 embassy-futures.workspace = true
-embedded-hal.workspace = true
-embedded-hal-async.workspace = true
-serprog.workspace = true
-embassy-rp = { workspace = true, features = ["unstable-pac", "time-driver", "critical-section-impl", "rom-func-cache", "rom-v2-intrinsics", "rp2040"] }
+embassy-rp = { workspace = true, features = ["critical-section-impl", "rom-func-cache", "rom-v2-intrinsics", "rp2040", "time-driver", "unstable-pac"] }
 embassy-sync.workspace = true
 embassy-time.workspace = true
-embassy-usb = { workspace = true, features = ["max-handler-count-6", "max-interface-count-6"] }
+embassy-usb = { workspace = true, features = ["max-handler-count-2", "max-interface-count-2"] }
 embassy-usb-logger.workspace = true
+embedded-hal.workspace = true
+embedded-hal-async.workspace = true
+futures = { workspace = true, default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
 heapless = { workspace = true, features = ["portable-atomic-critical-section", "ufmt"] }
 log.workspace = true
+portable-atomic = { workspace = true, features = ["critical-section"] }
+serprog.workspace = true
 static_cell.workspace = true
 ufmt.workspace = true

--- a/picoprog/Cargo.toml
+++ b/picoprog/Cargo.toml
@@ -9,18 +9,19 @@ authors = ["Marvin Drees <marvin.drees@9elements.com>"]
 assign-resources.workspace = true
 cortex-m = { workspace = true, features = ["critical-section", "inline-asm"] }
 cortex-m-rt.workspace = true
-embassy-executor = { workspace = true, features = ["arch-cortex-m", "executor-interrupt", "executor-thread", "nightly"] }
+defmt.workspace = true
+defmt-rtt.workspace = true
+embassy-executor = { workspace = true, features = ["arch-cortex-m", "defmt", "executor-interrupt", "executor-thread", "nightly"] }
 embassy-futures.workspace = true
-embassy-rp = { workspace = true, features = ["critical-section-impl", "rom-func-cache", "rom-v2-intrinsics", "rp2040", "time-driver", "unstable-pac"] }
-embassy-sync.workspace = true
-embassy-time.workspace = true
-embassy-usb = { workspace = true, features = ["max-handler-count-2", "max-interface-count-2"] }
-embassy-usb-logger.workspace = true
-embedded-hal.workspace = true
-embedded-hal-async.workspace = true
+embassy-rp = { workspace = true, features = ["critical-section-impl", "defmt", "rom-func-cache", "rom-v2-intrinsics", "rp2040", "time-driver", "unstable-pac"] }
+embassy-sync = { workspace = true, features = ["defmt"] }
+embassy-time = { workspace = true, features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-usb = { workspace = true, features = ["defmt"] }
+embedded-hal = { workspace = true, features = ["defmt-03"] }
+embedded-hal-async = { workspace = true, features = ["defmt-03"] }
 futures = { workspace = true, default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
 heapless = { workspace = true, features = ["portable-atomic-critical-section", "ufmt"] }
-log.workspace = true
+panic-probe = { workspace = true, features = ["print-defmt"] }
 portable-atomic = { workspace = true, features = ["critical-section"] }
 serprog.workspace = true
 static_cell.workspace = true

--- a/picoprog/build.rs
+++ b/picoprog/build.rs
@@ -32,4 +32,5 @@ fn main() {
     println!("cargo:rustc-link-arg-bins=--nmagic");
     println!("cargo:rustc-link-arg-bins=-Tlink.x");
     println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/picoprog/src/main.rs
+++ b/picoprog/src/main.rs
@@ -6,23 +6,23 @@
 #![feature(type_alias_impl_trait)]
 
 use assign_resources::assign_resources;
-use core::panic::PanicInfo;
-use cortex_m::peripheral::SCB;
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::flash::{Async, Flash};
+use embassy_rp::flash::{Async as AsyncFlash, Flash};
 use embassy_rp::gpio::{Level, Output};
+use embassy_rp::init;
 use embassy_rp::peripherals::{self, PIO0, SPI0, USB};
 use embassy_rp::pio::InterruptHandler as PIOInterruptHandler;
-use embassy_rp::spi::{Config as SpiConfig, Spi};
+use embassy_rp::spi::{Async as AsyncSpi, Config as SpiConfig, Spi};
 use embassy_rp::usb::{Driver, InterruptHandler as USBInterruptHandler};
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
-use embassy_usb::{Config as UsbConfig, UsbDevice};
-use embassy_usb_logger::with_class;
+use embassy_usb::Config as UsbConfig;
 use heapless::String;
 use static_cell::StaticCell;
 use ufmt::uwrite;
+use {defmt_rtt as _, panic_probe as _};
 
 mod uart;
 
@@ -55,11 +55,12 @@ const FLASH_SIZE: usize = 2 * 1024 * 1024;
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    let p = embassy_rp::init(Default::default());
+    let p = init(Default::default());
     let r = split_resources!(p);
     let driver = Driver::new(p.USB, Irqs);
 
-    let mut flash = Flash::<_, Async, FLASH_SIZE>::new(p.FLASH, p.DMA_CH4);
+    debug!("Reading unique ID from flash");
+    let mut flash = Flash::<_, AsyncFlash, FLASH_SIZE>::new(p.FLASH, p.DMA_CH4);
     let mut uid: [u8; 8] = [0; 8];
     flash.blocking_unique_id(&mut uid).unwrap_or_default();
 
@@ -68,6 +69,7 @@ async fn main(spawner: Spawner) {
     for byte in uid.iter() {
         uwrite!(uid_str, "{:02X}", *byte).unwrap_or_default();
     }
+    debug!("UID: {}", uid_str.as_str());
 
     let config = {
         let mut config = UsbConfig::new(0x1ced, 0xc0fe);
@@ -102,12 +104,6 @@ async fn main(spawner: Spawner) {
         builder
     };
 
-    let logger_class = {
-        static STATE: StaticCell<State> = StaticCell::new();
-        let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
-    };
-
     let uart_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
@@ -120,40 +116,26 @@ async fn main(spawner: Spawner) {
         CdcAcmClass::new(&mut builder, state, 64)
     };
 
-    let usb = builder.build();
+    debug!("Starting USB stack");
     // We can't really recover here so just unwrap
-    spawner.spawn(usb_task(usb)).unwrap();
-    spawner.spawn(logger_task(logger_class)).unwrap();
     spawner.spawn(uart::uart_task(uart_class, r.uart)).unwrap();
     spawner.spawn(serprog_task(serprog_class, r.spi)).unwrap();
 
-    loop {
-        embassy_time::Timer::after(embassy_time::Duration::from_secs(1)).await;
-    }
+    let mut usb = builder.build();
+    usb.run().await;
 }
 
 type CustomUsbDriver = Driver<'static, USB>;
-type CustomUsbDevice = UsbDevice<'static, CustomUsbDriver>;
 
 struct Disconnected {}
 
 impl From<EndpointError> for Disconnected {
     fn from(val: EndpointError) -> Self {
         match val {
-            EndpointError::BufferOverflow => panic!("USB buffer overflow"),
+            EndpointError::BufferOverflow => defmt::panic!("Buffer overflow"),
             EndpointError::Disabled => Disconnected {},
         }
     }
-}
-
-#[embassy_executor::task]
-async fn usb_task(mut usb: CustomUsbDevice) -> ! {
-    usb.run().await
-}
-
-#[embassy_executor::task]
-async fn logger_task(class: CdcAcmClass<'static, CustomUsbDriver>) {
-    with_class!(1024, log::LevelFilter::Info, class).await
 }
 
 #[embassy_executor::task]
@@ -173,19 +155,10 @@ async fn serprog_task(class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResour
     let cs = Output::new(r.cs, Level::High);
     let led = Output::new(r.led, Level::Low);
 
-    let set_freq_cb = move |spi: &mut Spi<'_, SPI0, embassy_rp::spi::Async>, freq| {
+    let set_freq_cb = move |spi: &mut Spi<'_, SPI0, AsyncSpi>, freq| {
         spi.set_frequency(freq);
     };
 
     let serprog = serprog::Serprog::new(spi, cs, led, class, Some(set_freq_cb));
     serprog.run_loop().await
-}
-
-#[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
-    // Print out the panic info
-    log::error!("Panic occurred: {:?}", info);
-
-    // Reboot the system
-    SCB::sys_reset();
 }

--- a/picoprog/src/uart.rs
+++ b/picoprog/src/uart.rs
@@ -1,3 +1,4 @@
+use defmt::*;
 use embassy_futures::join::join;
 use embassy_rp::peripherals::USB;
 use embassy_rp::pio::{Instance as PioInstance, Pio};
@@ -16,7 +17,7 @@ pub struct Disconnected {}
 impl From<EndpointError> for Disconnected {
     fn from(val: EndpointError) -> Self {
         match val {
-            EndpointError::BufferOverflow => panic!("USB buffer overflow"),
+            EndpointError::BufferOverflow => defmt::panic!("Buffer overflow"),
             EndpointError::Disabled => Disconnected {},
         }
     }
@@ -48,16 +49,16 @@ pub async fn uart_task(class: CdcAcmClass<'static, Driver<'static, USB>>, r: Uar
     // Read + write from USB
     let usb_future = async {
         loop {
-            log::debug!("[UART]: Wait for USB connection");
+            debug!("[UART]: Wait for USB connection");
             usb_rx.wait_connection().await;
-            log::debug!("[UART]: USB Connected");
+            debug!("[UART]: USB Connected");
             let _baud = usb_rx.line_coding().data_rate(); // TODO: Make use of this in the PIO program
             let _ = join(
                 usb_read(&mut usb_rx, &mut uart_pipe_writer),
                 usb_write(&mut usb_tx, &mut usb_pipe_reader),
             )
             .await;
-            log::debug!("[UART]: USB Disconnected");
+            debug!("[UART]: USB Disconnected");
         }
     };
 
@@ -79,7 +80,7 @@ async fn usb_read<'d, T: UsbInstance + 'd>(
     loop {
         let n = usb_rx.read_packet(&mut buf).await?;
         let data = &buf[..n];
-        log::debug!("[UART]: USB IN: {:?}", data);
+        debug!("[UART]: USB IN: {:?}", data);
         (*uart_pipe_writer).write(data).await;
     }
 }
@@ -93,7 +94,7 @@ async fn usb_write<'d, T: UsbInstance + 'd>(
     loop {
         let n = (*usb_pipe_reader).read(&mut buf).await;
         let data = &buf[..n];
-        log::debug!("[UART]: USB OUT: {:?}", data);
+        debug!("[UART]: USB OUT: {:?}", data);
         usb_tx.write_packet(data).await?;
     }
 }
@@ -106,7 +107,7 @@ async fn uart_read<PIO: PioInstance, const SM: usize>(
     loop {
         let byte = uart_rx.read_u8().await;
         let data = &[byte];
-        log::debug!("[UART]: UART IN: {:?}", data);
+        debug!("[UART]: UART IN: {:?}", data);
         (*usb_pipe_writer).write(data).await;
     }
 }
@@ -120,7 +121,7 @@ async fn uart_write<PIO: PioInstance, const SM: usize>(
     loop {
         let n = (*uart_pipe_reader).read(&mut buf).await;
         let data = &buf[..n];
-        log::debug!("[UART]: UART OUT: {:?}", data);
+        debug!("[UART]: UART OUT: {:?}", data);
         for &byte in data {
             uart_tx.write_u8(byte).await;
         }

--- a/serprog/Cargo.toml
+++ b/serprog/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-embassy-usb.workspace = true
-embedded-hal-async.workspace = true
-embedded-hal.workspace = true
+embassy-usb = { workspace = true, features = ["defmt"] }
+embedded-hal-async = { workspace = true, features = ["defmt-03"] }
+embedded-hal = { workspace = true, features = ["defmt-03"] }
+defmt.workspace = true
 futures = { workspace = true, default-features = false, features = ["async-await", "unstable"] }
-log.workspace = true
 num_enum = { workspace = true, default-features = false }
 tock-registers.workspace = true
 zerocopy = { workspace = true, features = ["derive"] }

--- a/serprog/Cargo.toml
+++ b/serprog/Cargo.toml
@@ -6,9 +6,10 @@ license = "Apache-2.0"
 
 [dependencies]
 embassy-usb.workspace = true
-embedded-hal.workspace = true
 embedded-hal-async.workspace = true
+embedded-hal.workspace = true
+futures = { workspace = true, default-features = false, features = ["async-await", "unstable"] }
 log.workspace = true
-num_enum.workspace = true
+num_enum = { workspace = true, default-features = false }
 tock-registers.workspace = true
-zerocopy.workspace = true
+zerocopy = { workspace = true, features = ["derive"] }

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -2,6 +2,7 @@
 
 use core::convert::From;
 use core::result::Result::{Err, Ok};
+use defmt::*;
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::SpiBus;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -212,7 +213,7 @@ where
 
         loop {
             if let Err(e) = self.transport.read(&mut buf).await {
-                log::error!("Read error: {:?}", e);
+                error!("Read error: {:?}", e);
                 continue;
             }
 
@@ -229,84 +230,84 @@ where
     {
         match cmd {
             SerprogCommand::Nop => {
-                log::debug!("Received Nop CMD");
+                debug!("Received Nop CMD");
                 if let Err(e) = self.transport.write(&[S_ACK]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QIface => {
-                log::debug!("Received QIface CMD");
+                debug!("Received QIface CMD");
                 let response = QIfaceResponse {
                     ack: S_ACK,
                     version: U16::new(1),
                 };
                 if let Err(e) = self.transport.write(response.as_bytes()).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QCmdMap => {
-                log::debug!("Received QCmdMap CMD");
+                debug!("Received QCmdMap CMD");
                 let response = QCmdMapResponse::new(self.freq_callback.is_some());
                 if let Err(e) = self.transport.write(response.as_bytes()).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QPgmName => {
-                log::debug!("Received QPgmName CMD");
+                debug!("Received QPgmName CMD");
                 let response = QPgmNameResponse::new("Picoprog");
                 if let Err(e) = self.transport.write(response.as_bytes()).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QSerBuf => {
-                log::debug!("Received QSerBuf CMD");
+                debug!("Received QSerBuf CMD");
                 if let Err(e) = self.transport.write(&[S_ACK, 0xFF, 0xFF]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QWrNMaxLen | SerprogCommand::QRdNMaxLen => {
-                log::debug!("Received QWrNMaxLen/QRdNMaxLen CMD");
+                debug!("Received QWrNMaxLen/QRdNMaxLen CMD");
                 let response = QMaxLenResponse::new(MAX_BUFFER_SIZE);
                 if let Err(e) = self.transport.write(response.as_bytes()).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::QBustype => {
-                log::debug!("Received QBustype CMD");
+                debug!("Received QBustype CMD");
                 if let Err(e) = self.transport.write(&[S_ACK, 0x08]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::SyncNop => {
-                log::debug!("Received SyncNop CMD");
+                debug!("Received SyncNop CMD");
                 if let Err(e) = self.transport.write(&[S_NAK, S_ACK]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::SBustype => {
-                log::debug!("Received SBustype CMD");
+                debug!("Received SBustype CMD");
                 let mut buf = [0u8; 1];
                 if let Err(e) = self.transport.read(&mut buf).await {
-                    log::error!("Error reading packet: {:?}", e);
+                    error!("Error reading packet: {:?}", e);
                     return;
                 }
                 if buf[0] == 0x08 {
-                    log::debug!("Received SBustype 'SPI'");
+                    debug!("Received SBustype 'SPI'");
                     if let Err(e) = self.transport.write(&[S_ACK]).await {
-                        log::error!("Error writing packet: {:?}", e);
+                        error!("Error writing packet: {:?}", e);
                     }
                 } else {
-                    log::debug!("Received unknown SBustype");
+                    debug!("Received unknown SBustype");
                     if let Err(e) = self.transport.write(&[S_NAK]).await {
-                        log::error!("Error writing packet: {:?}", e);
+                        error!("Error writing packet: {:?}", e);
                     }
                 }
             }
             SerprogCommand::OSpiOp => {
-                log::debug!("Received OSpiOp CMD");
+                debug!("Received OSpiOp CMD");
                 let mut sdata = [0_u8; MAX_BUFFER_SIZE + 6];
                 if let Err(e) = self.transport.read(sdata.as_mut_slice()).await {
-                    log::error!("Error reading packet: {:?}", e);
+                    error!("Error reading packet: {:?}", e);
                     return;
                 }
                 let op_slen = le_u24_to_u32(&sdata[0..3]) as usize;
@@ -316,7 +317,7 @@ where
 
                 let sdata = &sdata.as_slice()[6..6 + op_slen];
 
-                log::debug!(
+                debug!(
                     "Starting SPI transfer, sdata: {:?}, rdata: {:?}",
                     &sdata[..op_slen as usize],
                     &rdata[..op_rlen as usize]
@@ -324,63 +325,60 @@ where
 
                 // This call is blocking according to the SPI HAL
                 if (self.spi.flush().await).is_err() {
-                    log::error!("Error flushing SPI");
+                    error!("Error flushing SPI");
                 }
 
                 if self.cs.set_low().is_err() {
-                    log::error!("Error setting CS low");
+                    error!("Error setting CS low");
                 }
 
                 match self.spi.write(&sdata[..op_slen as usize]).await {
                     Ok(_) => {
-                        log::debug!("SPI transfer successful");
-                        log::debug!("Received data (rdata): {:?}", &rdata[..op_rlen as usize]);
+                        debug!("SPI transfer successful");
+                        debug!("Received data (rdata): {:?}", &rdata[..op_rlen as usize]);
                         match self.spi.read(&mut rdata[..op_rlen as usize]).await {
                             Ok(_) => {
-                                log::debug!("SPI read successful");
-                                log::debug!(
-                                    "Received data (rdata): {:?}",
-                                    &rdata[..op_rlen as usize]
-                                );
+                                debug!("SPI read successful");
+                                debug!("Received data (rdata): {:?}", &rdata[..op_rlen as usize]);
                                 if let Err(e) = self.transport.write(&[S_ACK]).await {
-                                    log::error!("Error writing packet: {:?}", e);
+                                    error!("Error writing packet: {:?}", e);
                                 }
 
                                 // Send the full rdata in chunks
                                 let _ = self.transport.write(&rdata[..op_rlen as usize]).await;
                             }
-                            Err(e) => {
-                                log::error!("SPI read error: {:?}", e);
+                            Err(_e) => {
+                                //error!("SPI read error: {:?}", e); TODO: Fix
                                 if let Err(e) = self.transport.write(&[S_NAK]).await {
-                                    log::error!("Error writing NAK: {:?}", e);
+                                    error!("Error writing NAK: {:?}", e);
                                 }
                             }
                         }
                     }
                     Err(_) => {
-                        log::error!("SPI transfer error");
+                        error!("SPI transfer error");
                         if let Err(e) = self.transport.write(&[S_NAK]).await {
-                            log::error!("Error writing NAK: {:?}", e);
+                            error!("Error writing NAK: {:?}", e);
                         }
                     }
                 }
 
                 if self.cs.set_high().is_err() {
-                    log::error!("Error setting CS high");
+                    error!("Error setting CS high");
                 }
             }
             SerprogCommand::SSpiFreq => {
-                log::debug!("Received SSpiFreq CMD");
+                debug!("Received SSpiFreq CMD");
                 let mut request = SSpiFreqRequest::new_zeroed();
                 if let Err(e) = self.transport.read(request.as_mut_bytes()).await {
-                    log::error!("Error reading packet: {:?}", e);
+                    error!("Error reading packet: {:?}", e);
                     return;
                 }
 
                 // Parse the request using zerocopy
                 let try_freq = request.freq.get();
 
-                log::debug!("Setting SPI frequency: {:?}", try_freq);
+                debug!("Setting SPI frequency: {:?}", try_freq);
 
                 // Call the frequency callback if set
                 if let Some(callback) = &mut self.freq_callback {
@@ -394,31 +392,31 @@ where
                 };
 
                 if let Err(e) = self.transport.write(response.as_bytes()).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             SerprogCommand::SPinState => {
-                log::debug!("Received SPinState CMD");
+                debug!("Received SPinState CMD");
                 let mut buf = [0u8; 1];
                 if let Err(e) = self.transport.read(&mut buf).await {
-                    log::error!("Error reading packet: {:?}", e);
+                    error!("Error reading packet: {:?}", e);
                     return;
                 }
                 if buf[0] == 0 {
                     if self.led.set_low().is_err() {
-                        log::error!("Error setting LED low");
+                        error!("Error setting LED low");
                     }
                 } else if self.led.set_high().is_err() {
-                    log::error!("Error setting LED high");
+                    error!("Error setting LED high");
                 }
                 if let Err(e) = self.transport.write(&[S_ACK]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
             _ => {
-                log::debug!("Received unknown CMD");
+                debug!("Received unknown CMD");
                 if let Err(e) = self.transport.write(&[S_NAK]).await {
-                    log::error!("Error writing packet: {:?}", e);
+                    error!("Error writing packet: {:?}", e);
                 }
             }
         }


### PR DESCRIPTION
This will get rid of the logging via USB and instead use defmt. As the USB logging was never really useful and impacted speeds it has been replaced by the much more powerful defmt logging which also has better integration in embassy.