### PR TITLE
Fix build instructions for Raspberry Pi Pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd picoprog
 
 For Raspberry Pi Pico:
 ```sh
+cd picoprog
 cargo run --release
 ```
 


### PR DESCRIPTION
Added instructions to enter the `picoprog` directory when building for Raspberry Pi Pico