### PR TITLE
Add configurable USB buffer size with zero-copy optimization for OSpiOp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "heapless 0.9.1",
  "num_enum",
  "tock-registers",
  "zerocopy 0.8.17",

--- a/bluepill-prog/src/main.rs
+++ b/bluepill-prog/src/main.rs
@@ -50,6 +50,8 @@ assign_resources! {
     }
 }
 
+const USB_BUFFER_SIZE: usize = 64;
+
 // According to Serial Flasher Protocol Specification - version 1
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
@@ -131,7 +133,7 @@ async fn main(spawner: Spawner) {
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let usb = builder.build();
@@ -190,7 +192,13 @@ async fn serprog_task(mut class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiRe
 
     loop {
         class.wait_connection().await;
-        let serprog = serprog::Serprog::new(spi, cs, led, class, Some(set_freq_cb));
+        let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
+            spi,
+            cs,
+            led,
+            class,
+            Some(set_freq_cb),
+        );
         serprog.run_loop().await
     }
 }

--- a/bluepill-prog/src/main.rs
+++ b/bluepill-prog/src/main.rs
@@ -133,7 +133,7 @@ async fn main(spawner: Spawner) {
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE as u16)
     };
 
     let usb = builder.build();

--- a/picoprog/src/main.rs
+++ b/picoprog/src/main.rs
@@ -107,13 +107,13 @@ async fn main(spawner: Spawner) {
     let uart_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE as u16)
     };
 
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE as u16)
     };
 
     let usb = builder.build();

--- a/picoprog/src/main.rs
+++ b/picoprog/src/main.rs
@@ -51,6 +51,7 @@ assign_resources! {
 }
 
 const FLASH_SIZE: usize = 2 * 1024 * 1024;
+const USB_BUFFER_SIZE: usize = 64;
 
 // According to Serial Flasher Protocol Specification - version 1
 
@@ -106,13 +107,13 @@ async fn main(spawner: Spawner) {
     let uart_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let usb = builder.build();
@@ -166,7 +167,13 @@ async fn serprog_task(class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResour
         spi.set_frequency(freq);
     };
 
-    let serprog = serprog::Serprog::new(spi, cs, led, class, Some(set_freq_cb));
+    let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
+        spi,
+        cs,
+        led,
+        class,
+        Some(set_freq_cb),
+    );
     serprog.run_loop().await
 }
 

--- a/serprog/Cargo.toml
+++ b/serprog/Cargo.toml
@@ -11,6 +11,7 @@ embassy-sync.workspace = true
 embedded-hal.workspace = true
 embedded-hal-async.workspace = true
 #log.workspace = true
+heapless.workspace = true
 defmt.workspace = true
 num_enum.workspace = true
 tock-registers.workspace = true

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -217,6 +217,8 @@ async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize
     // First block - already contains header + initial data, send as-is
     let mut data_to_read = sdata_size;
     let first_block_data_size = data_to_read.min(TRANSFER_SIZE - 6);
+    // Acquire the pre-populated buffer per channel protocol, but do not modify it.
+    let _ = sender.send().await;
     sender.send_done();
     data_to_read -= first_block_data_size;
 
@@ -224,7 +226,8 @@ async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize
         let read_size = data_to_read.min(TRANSFER_SIZE);
         let buf = sender.send().await;
         buf.clear();
-        buf.resize(read_size, 0).ok();
+        buf.resize(read_size, 0)
+            .map_err(|_| SerprogError::TransportRead("Error resizing OSpiOp read buffer"))?;
         transport
             .read(buf.as_mut_slice())
             .await
@@ -235,7 +238,7 @@ async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize
     transport
         .write(&[S_ACK])
         .await
-        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
+        .map_err(|_| SerprogError::TransportWrite("Error writing OSpiOp ACK"))?;
 
     let mut data_to_send = rdata_size;
     while data_to_send > 0 {
@@ -289,7 +292,8 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: us
         let buf = sender.send().await;
         buf.clear();
         let read_size = data_to_read.min(TRANSFER_SIZE);
-        buf.resize(read_size, 0).ok();
+        buf.resize(read_size, 0)
+            .map_err(|_| SerprogError::SpiTransfer("Error resizing OSpiOp SPI read buffer"))?;
         spi.read(buf.as_mut_slice())
             .await
             .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
@@ -444,7 +448,9 @@ where
 
                 // Read directly into the first channel buffer
                 let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
-                usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
+                usb_rx_spi_tx_buf[0]
+                    .resize(TRANSFER_SIZE, 0)
+                    .map_err(|_| SerprogError::TransportRead("Error resizing OSpiOp buffer"))?;
                 self.transport
                     .read(usb_rx_spi_tx_buf[0].as_mut_slice())
                     .await

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -7,6 +7,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::SpiBus;
+use heapless::Vec;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use tock_registers::register_bitfields;
 use tock_registers::LocalRegisterCopy;
@@ -341,48 +342,46 @@ where
             }
             SerprogCommand::OSpiOp => {
                 debug!("Received OSpiOp CMD");
-                let mut sdata = [0_u8; 64];
+
+                // Read directly into the first channel buffer
+                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, 64>::new() }; 4];
+                usb_rx_spi_tx_buf[0].resize(64, 0).ok();
                 self.transport
-                    .read(sdata.as_mut_slice())
+                    .read(usb_rx_spi_tx_buf[0].as_mut_slice())
                     .await
                     .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
 
-                let op_slen = le_u24_to_u32(&sdata[0..3]) as usize;
-                let op_rlen = le_u24_to_u32(&sdata[3..6]) as usize;
+                // Parse header from the first buffer
+                let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
+                let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
 
-                let mut usb_rx_spi_tx_buf = [([0u8; 64], 0); 4];
-                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, ([u8; 64], usize)> =
+                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
                     Channel::new(&mut usb_rx_spi_tx_buf);
                 let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
 
-                let mut usb_tx_spi_rx_buf = [([0u8; 64], 0); 8];
-                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, ([u8; 64], usize)> =
+                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, 64>::new() }; 8];
+                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
                 let usb_task = async |transport: &mut T,
-                                      mut sender: Sender<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
                                       sdata_size: usize,
-                                      sdata_0: [u8; 64],
-                                      mut receiver: Receiver<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
                                       rdata_size: usize|
                        -> Result<(), SerprogError> {
-                    // First block
+                    // First block - already contains header + initial data, send as-is
                     let mut data_to_read = sdata_size;
-                    {
-                        let (buf, size) = sender.send().await;
-                        let block_size = data_to_read.min(64 - 6);
-                        buf[..block_size].copy_from_slice(&sdata_0[6..6 + block_size]);
-                        *size = block_size;
-                        sender.send_done();
-                        data_to_read -= block_size;
-                    }
+                    let first_block_data_size = data_to_read.min(64 - 6);
+                    sender.send_done();
+                    data_to_read -= first_block_data_size;
 
                     while data_to_read > 0 {
                         let read_size = data_to_read.min(64);
-                        let (buf, size) = sender.send().await;
-                        *size = read_size;
-                        transport.read(&mut buf[..read_size]).await.map_err(|_| {
+                        let buf = sender.send().await;
+                        buf.clear();
+                        buf.resize(read_size, 0).ok();
+                        transport.read(buf.as_mut_slice()).await.map_err(|_| {
                             SerprogError::TransportRead("Error reading OSpiOp data")
                         })?;
                         sender.send_done();
@@ -395,21 +394,20 @@ where
 
                     let mut data_to_send = rdata_size;
                     while data_to_send > 0 {
-                        let (buf, size) = receiver.receive().await;
-                        let size = *size;
-                        transport.write(&buf[..size]).await.map_err(|_| {
+                        let buf = receiver.receive().await;
+                        transport.write(buf.as_slice()).await.map_err(|_| {
                             SerprogError::TransportWrite("Error writing SPI read data")
                         })?;
+                        data_to_send -= buf.len();
                         receiver.receive_done();
-                        data_to_send -= size;
                     }
                     Ok(())
                 };
 
                 let spi_task = async |spi: &mut SPI,
-                                      mut receiver: Receiver<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
                                       sdata_size: usize,
-                                      mut sender: Sender<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
                                       rdata_size: usize,
                                       cs: &mut CS|
                        -> Result<(), SerprogError> {
@@ -420,22 +418,34 @@ where
                     cs.set_low()
                         .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
                     let mut data_to_write = sdata_size;
+                    let mut is_first = true;
                     while data_to_write > 0 {
-                        let (buf, size) = receiver.receive().await;
-                        data_to_write -= *size;
-                        spi.write(&buf[..*size])
+                        let buf = receiver.receive().await;
+                        let write_slice = if is_first {
+                            // First buffer: skip the 6-byte header
+                            is_first = false;
+                            let data_len = data_to_write.min(64 - 6);
+                            data_to_write -= data_len;
+                            &buf[6..6 + data_len]
+                        } else {
+                            // Subsequent buffers: use entire buffer
+                            data_to_write -= buf.len();
+                            buf.as_slice()
+                        };
+                        spi.write(write_slice)
                             .await
                             .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
                         receiver.receive_done();
                     }
                     let mut data_to_read = rdata_size;
                     while data_to_read > 0 {
-                        let (buf, size) = sender.send().await;
-                        let read_size = data_to_read.min(buf.len());
-                        spi.read(&mut buf[..read_size])
+                        let buf = sender.send().await;
+                        buf.clear();
+                        let read_size = data_to_read.min(64);
+                        buf.resize(read_size, 0).ok();
+                        spi.read(buf.as_mut_slice())
                             .await
                             .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
-                        *size = read_size;
                         sender.send_done();
                         data_to_read -= read_size;
                     }
@@ -454,7 +464,7 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    usb_task(&mut self.transport, usb_rx, op_slen, sdata, usb_tx, op_rlen),
+                    usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -207,6 +207,101 @@ pub struct Serprog<SPI, CS, LED, T: Transport, F> {
     freq_callback: Option<F>,
 }
 
+async fn ospiop_usb_task<T: Transport>(
+    transport: &mut T,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    sdata_size: usize,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    rdata_size: usize,
+) -> Result<(), SerprogError> {
+    // First block - already contains header + initial data, send as-is
+    let mut data_to_read = sdata_size;
+    let first_block_data_size = data_to_read.min(64 - 6);
+    sender.send_done();
+    data_to_read -= first_block_data_size;
+
+    while data_to_read > 0 {
+        let read_size = data_to_read.min(64);
+        let buf = sender.send().await;
+        buf.clear();
+        buf.resize(read_size, 0).ok();
+        transport
+            .read(buf.as_mut_slice())
+            .await
+            .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+        sender.send_done();
+        data_to_read -= read_size;
+    }
+    transport
+        .write(&[S_ACK])
+        .await
+        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
+
+    let mut data_to_send = rdata_size;
+    while data_to_send > 0 {
+        let buf = receiver.receive().await;
+        transport
+            .write(buf.as_slice())
+            .await
+            .map_err(|_| SerprogError::TransportWrite("Error writing SPI read data"))?;
+        data_to_send -= buf.len();
+        receiver.receive_done();
+    }
+    Ok(())
+}
+
+async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
+    spi: &mut SPI,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    sdata_size: usize,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    rdata_size: usize,
+    cs: &mut CS,
+) -> Result<(), SerprogError> {
+    spi.flush()
+        .await
+        .map_err(|_| SerprogError::SpiFlush("Error flushing SPI before transfer"))?;
+
+    cs.set_low()
+        .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
+    let mut data_to_write = sdata_size;
+    let mut is_first = true;
+    while data_to_write > 0 {
+        let buf = receiver.receive().await;
+        let write_slice = if is_first {
+            // First buffer: skip the 6-byte header
+            is_first = false;
+            let data_len = data_to_write.min(64 - 6);
+            data_to_write -= data_len;
+            &buf[6..6 + data_len]
+        } else {
+            // Subsequent buffers: use entire buffer
+            data_to_write -= buf.len();
+            buf.as_slice()
+        };
+        spi.write(write_slice)
+            .await
+            .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
+        receiver.receive_done();
+    }
+    let mut data_to_read = rdata_size;
+    while data_to_read > 0 {
+        let buf = sender.send().await;
+        buf.clear();
+        let read_size = data_to_read.min(64);
+        buf.resize(read_size, 0).ok();
+        spi.read(buf.as_mut_slice())
+            .await
+            .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
+        sender.send_done();
+        data_to_read -= read_size;
+    }
+    cs.set_high()
+        .map_err(|_| SerprogError::CsSetHigh("Error setting CS high"))?;
+    debug!("OSpiOp CMD done");
+    Ok(())
+}
+
 impl<SPI, CS, LED, T, F> Serprog<SPI, CS, LED, T, F>
 where
     SPI: SpiBus<u8>,
@@ -364,99 +459,8 @@ where
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
-                let usb_task = async |transport: &mut T,
-                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
-                                      sdata_size: usize,
-                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
-                                      rdata_size: usize|
-                       -> Result<(), SerprogError> {
-                    // First block - already contains header + initial data, send as-is
-                    let mut data_to_read = sdata_size;
-                    let first_block_data_size = data_to_read.min(64 - 6);
-                    sender.send_done();
-                    data_to_read -= first_block_data_size;
-
-                    while data_to_read > 0 {
-                        let read_size = data_to_read.min(64);
-                        let buf = sender.send().await;
-                        buf.clear();
-                        buf.resize(read_size, 0).ok();
-                        transport.read(buf.as_mut_slice()).await.map_err(|_| {
-                            SerprogError::TransportRead("Error reading OSpiOp data")
-                        })?;
-                        sender.send_done();
-                        data_to_read -= read_size;
-                    }
-                    transport
-                        .write(&[S_ACK])
-                        .await
-                        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
-
-                    let mut data_to_send = rdata_size;
-                    while data_to_send > 0 {
-                        let buf = receiver.receive().await;
-                        transport.write(buf.as_slice()).await.map_err(|_| {
-                            SerprogError::TransportWrite("Error writing SPI read data")
-                        })?;
-                        data_to_send -= buf.len();
-                        receiver.receive_done();
-                    }
-                    Ok(())
-                };
-
-                let spi_task = async |spi: &mut SPI,
-                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
-                                      sdata_size: usize,
-                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
-                                      rdata_size: usize,
-                                      cs: &mut CS|
-                       -> Result<(), SerprogError> {
-                    spi.flush().await.map_err(|_| {
-                        SerprogError::SpiFlush("Error flushing SPI before transfer")
-                    })?;
-
-                    cs.set_low()
-                        .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
-                    let mut data_to_write = sdata_size;
-                    let mut is_first = true;
-                    while data_to_write > 0 {
-                        let buf = receiver.receive().await;
-                        let write_slice = if is_first {
-                            // First buffer: skip the 6-byte header
-                            is_first = false;
-                            let data_len = data_to_write.min(64 - 6);
-                            data_to_write -= data_len;
-                            &buf[6..6 + data_len]
-                        } else {
-                            // Subsequent buffers: use entire buffer
-                            data_to_write -= buf.len();
-                            buf.as_slice()
-                        };
-                        spi.write(write_slice)
-                            .await
-                            .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
-                        receiver.receive_done();
-                    }
-                    let mut data_to_read = rdata_size;
-                    while data_to_read > 0 {
-                        let buf = sender.send().await;
-                        buf.clear();
-                        let read_size = data_to_read.min(64);
-                        buf.resize(read_size, 0).ok();
-                        spi.read(buf.as_mut_slice())
-                            .await
-                            .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
-                        sender.send_done();
-                        data_to_read -= read_size;
-                    }
-                    cs.set_high()
-                        .map_err(|_| SerprogError::CsSetHigh("Error setting CS high"))?;
-                    debug!("OSpiOp CMD done");
-                    Ok(())
-                };
-
                 let (spi_res, usb_res) = block_on(join(
-                    spi_task(
+                    ospiop_spi_task(
                         &mut self.spi,
                         spi_tx,
                         op_slen,
@@ -464,7 +468,7 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
+                    ospiop_usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -199,7 +199,7 @@ impl QCmdMapResponse {
     }
 }
 
-pub struct Serprog<SPI, CS, LED, T: Transport, F> {
+pub struct Serprog<SPI, CS, LED, T: Transport<TRANSFER_SIZE>, F, const TRANSFER_SIZE: usize> {
     spi: SPI,
     cs: CS,
     led: LED,
@@ -207,21 +207,21 @@ pub struct Serprog<SPI, CS, LED, T: Transport, F> {
     freq_callback: Option<F>,
 }
 
-async fn ospiop_usb_task<T: Transport>(
+async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize>(
     transport: &mut T,
-    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     sdata_size: usize,
-    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     rdata_size: usize,
 ) -> Result<(), SerprogError> {
     // First block - already contains header + initial data, send as-is
     let mut data_to_read = sdata_size;
-    let first_block_data_size = data_to_read.min(64 - 6);
+    let first_block_data_size = data_to_read.min(TRANSFER_SIZE - 6);
     sender.send_done();
     data_to_read -= first_block_data_size;
 
     while data_to_read > 0 {
-        let read_size = data_to_read.min(64);
+        let read_size = data_to_read.min(TRANSFER_SIZE);
         let buf = sender.send().await;
         buf.clear();
         buf.resize(read_size, 0).ok();
@@ -250,11 +250,11 @@ async fn ospiop_usb_task<T: Transport>(
     Ok(())
 }
 
-async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
+async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: usize>(
     spi: &mut SPI,
-    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     sdata_size: usize,
-    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     rdata_size: usize,
     cs: &mut CS,
 ) -> Result<(), SerprogError> {
@@ -271,7 +271,7 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
         let write_slice = if is_first {
             // First buffer: skip the 6-byte header
             is_first = false;
-            let data_len = data_to_write.min(64 - 6);
+            let data_len = data_to_write.min(TRANSFER_SIZE - 6);
             data_to_write -= data_len;
             &buf[6..6 + data_len]
         } else {
@@ -288,7 +288,7 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
     while data_to_read > 0 {
         let buf = sender.send().await;
         buf.clear();
-        let read_size = data_to_read.min(64);
+        let read_size = data_to_read.min(TRANSFER_SIZE);
         buf.resize(read_size, 0).ok();
         spi.read(buf.as_mut_slice())
             .await
@@ -302,12 +302,12 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
     Ok(())
 }
 
-impl<SPI, CS, LED, T, F> Serprog<SPI, CS, LED, T, F>
+impl<SPI, CS, LED, T, F, const TRANSFER_SIZE: usize> Serprog<SPI, CS, LED, T, F, TRANSFER_SIZE>
 where
     SPI: SpiBus<u8>,
     CS: OutputPin,
     LED: OutputPin,
-    T: Transport,
+    T: Transport<TRANSFER_SIZE>,
     F: FnMut(&mut SPI, u32) + Send + Sync,
 {
     pub fn new(spi: SPI, cs: CS, led: LED, transport: T, freq_callback: Option<F>) -> Self {
@@ -320,7 +320,11 @@ where
         }
     }
 
-    pub async fn run_loop(mut self) -> ! {
+    pub async fn run_loop(mut self) -> !
+    where
+        CS::Error: core::fmt::Debug,
+        LED::Error: core::fmt::Debug,
+    {
         let mut buf = [0; 1];
 
         loop {
@@ -439,8 +443,8 @@ where
                 debug!("Received OSpiOp CMD");
 
                 // Read directly into the first channel buffer
-                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, 64>::new() }; 4];
-                usb_rx_spi_tx_buf[0].resize(64, 0).ok();
+                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
+                usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
                 self.transport
                     .read(usb_rx_spi_tx_buf[0].as_mut_slice())
                     .await
@@ -450,17 +454,17 @@ where
                 let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
                 let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
 
-                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
+                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
                     Channel::new(&mut usb_rx_spi_tx_buf);
                 let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
 
-                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, 64>::new() }; 8];
-                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
+                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 8];
+                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
                 let (spi_res, usb_res) = block_on(join(
-                    ospiop_spi_task(
+                    ospiop_spi_task::<_, _, TRANSFER_SIZE>(
                         &mut self.spi,
                         spi_tx,
                         op_slen,
@@ -468,7 +472,13 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    ospiop_usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
+                    ospiop_usb_task::<_, TRANSFER_SIZE>(
+                        &mut self.transport,
+                        usb_rx,
+                        op_slen,
+                        usb_tx,
+                        op_rlen,
+                    ),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/transport.rs
+++ b/serprog/src/transport.rs
@@ -1,18 +1,20 @@
 use core::future;
 use embassy_usb::class::cdc_acm::CdcAcmClass;
 
-pub trait Transport {
+pub trait Transport<const TRANSFER_SIZE: usize> {
     fn read(&mut self, buf: &mut [u8]) -> impl future::Future<Output = Result<(), ()>>;
     fn write(&mut self, data: &[u8]) -> impl future::Future<Output = Result<(), ()>>;
 }
 
-impl<'d, D: embassy_usb::driver::Driver<'d>> Transport for CdcAcmClass<'d, D> {
+impl<'d, D: embassy_usb::driver::Driver<'d>, const TRANSFER_SIZE: usize> Transport<TRANSFER_SIZE>
+    for CdcAcmClass<'d, D>
+{
     async fn read(&mut self, buf: &mut [u8]) -> Result<(), ()> {
         let packet_size = self.max_packet_size() as usize;
         let buf_len = buf.len();
 
         // Use a buffer large enough for full speed and high speed
-        let mut buffer = [0; 512];
+        let mut buffer = [0; TRANSFER_SIZE];
         let mut size = 0;
         if buf_len < packet_size {
             let bytes_read = self


### PR DESCRIPTION
This change introduces compile-time configuration of USB buffer sizes and optimizes the OSpiOp command implementation to eliminate unnecessary data copies.

**Key changes:**

- Made the `Serprog` struct generic over `TRANSFER_SIZE` constant, allowing buffer size configuration at compile time
- Updated `Transport` trait to be generic over the transfer size
- Refactored OSpiOp implementation to use `heapless::Vec` instead of fixed arrays, enabling more flexible buffer management
- Eliminated redundant data copies in OSpiOp by reading USB data directly into channel buffers
- Extracted `ospiop_usb_task` and `ospiop_spi_task` as separate functions for better code organization
- Added `heapless` dependency for stack-allocated vectors
- Set `USB_BUFFER_SIZE` to 64 bytes in both bluepill-prog and picoprog implementations

**Implementation details:**

The OSpiOp command previously copied data from USB to a temporary buffer, then to channel buffers. Now it reads directly into the channel's first buffer, parsing the header in place and avoiding the extra copy. This reduces memory overhead and improves performance for large SPI operations.