### PR TITLE
Add a timeout to USB operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "heapless 0.9.1",
  "num_enum",
  "tock-registers",
  "zerocopy 0.8.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-sync",
+ "embassy-time",
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/bluepill-prog/src/main.rs
+++ b/bluepill-prog/src/main.rs
@@ -50,6 +50,8 @@ assign_resources! {
     }
 }
 
+const USB_BUFFER_SIZE: usize = 64;
+
 // According to Serial Flasher Protocol Specification - version 1
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
@@ -131,7 +133,7 @@ async fn main(spawner: Spawner) {
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let usb = builder.build();
@@ -190,7 +192,13 @@ async fn serprog_task(mut class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiRe
 
     loop {
         class.wait_connection().await;
-        let serprog = serprog::Serprog::new(spi, cs, led, class, Some(set_freq_cb));
+        let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
+            spi,
+            cs,
+            led,
+            class,
+            Some(set_freq_cb),
+        );
         serprog.run_loop().await
     }
 }

--- a/bluepill-prog/src/main.rs
+++ b/bluepill-prog/src/main.rs
@@ -12,7 +12,7 @@ use core::panic::PanicInfo;
 use cortex_m::peripheral::SCB;
 use embassy_executor::Spawner;
 use embassy_stm32::bind_interrupts;
-use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::gpio::{Flex, Level, Output, Speed};
 use embassy_stm32::peripherals::{self, USB};
 use embassy_stm32::spi::{Config as SpiConfig, Spi};
 use embassy_stm32::time::Hertz;
@@ -166,41 +166,105 @@ async fn usb_task(mut usb: CustomUsbDevice) -> ! {
     usb.run().await
 }
 
-#[embassy_executor::task]
-async fn serprog_task(mut class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResources) -> ! {
-    let mut config = SpiConfig::default();
-    config.frequency = Hertz(12_000_000); // 12 MHz
+/// Provider for SPI device that creates SPI on demand
+struct SpiProvider {
+    peripheral: Peri<'static, peripherals::SPI1>,
+    clk: Peri<'static, peripherals::PA5>,
+    mosi: Peri<'static, peripherals::PA7>,
+    miso: Peri<'static, peripherals::PA6>,
+    mosi_dma: Peri<'static, peripherals::DMA1_CH3>,
+    miso_dma: Peri<'static, peripherals::DMA1_CH2>,
+    cs: Peri<'static, peripherals::PA4>,
+}
 
-    let spi = Spi::new(
-        r.peripheral,
-        r.clk,
-        r.mosi,
-        r.miso,
-        r.mosi_dma,
-        r.miso_dma,
-        config,
-    );
-    let cs = Output::new(r.cs, Level::High, Speed::Low);
-    let led = Output::new(r.led, Level::Low, Speed::Low);
+/// Reset a GPIO pin to analog/high-impedance state on STM32.
+/// We create a Flex from a stolen AnyPin and immediately drop it,
+/// which calls set_as_disconnected() (analog mode).
+fn reset_pin_stm32(pin_port: u8) {
+    use embassy_stm32::gpio::AnyPin;
 
-    // Define a callback function to set the SPI frequency
-    let set_freq_cb = move |spi: &mut Spi<'_, embassy_stm32::mode::Async>, freq| {
+    // SAFETY: We're resetting a pin we logically own. The Peri for this pin
+    // was already used to create SPI/Output which are about to be dropped.
+    // Creating a temporary AnyPin to reset it is safe.
+    // AnyPin::steal returns Peri<'static, AnyPin>
+    let peri = unsafe { AnyPin::steal(pin_port) };
+    // Create Flex - when Flex drops it calls set_as_disconnected() (analog mode)
+    let _ = Flex::new(peri);
+}
+
+impl serprog::SpiDeviceProvider for SpiProvider {
+    type Guard<'a>
+        = SpiGuard<'a>
+    where
+        Self: 'a;
+
+    fn acquire(&mut self, freq_hz: u32) -> Self::Guard<'_> {
         let mut config = SpiConfig::default();
-        config.frequency = Hertz(freq);
-        let _ = spi.set_config(&config);
-    };
+        config.frequency = Hertz(freq_hz);
 
-    loop {
-        class.wait_connection().await;
-        let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
+        // Reborrow the peripherals - pins are now configured as SPI outputs
+        let spi = Spi::new(
+            self.peripheral.reborrow(),
+            self.clk.reborrow(),
+            self.mosi.reborrow(),
+            self.miso.reborrow(),
+            self.mosi_dma.reborrow(),
+            self.miso_dma.reborrow(),
+            config,
+        );
+        let cs = Output::new(self.cs.reborrow(), Level::High, Speed::Low);
+
+        SpiGuard {
             spi,
             cs,
-            led,
-            class,
-            Some(set_freq_cb),
-        );
-        serprog.run_loop().await
+            // Store pin_port values for reset on drop
+            // Port A = 0, so PA4=4, PA5=5, PA6=6, PA7=7
+            pin_ports: [5, 7, 6, 4], // CLK=PA5, MOSI=PA7, MISO=PA6, CS=PA4
+        }
     }
+}
+
+/// Guard that holds SPI and CS, resetting pins to high-impedance (analog) on drop.
+struct SpiGuard<'a> {
+    spi: Spi<'a, embassy_stm32::mode::Async>,
+    cs: Output<'a>,
+    /// Pin port values to reset on drop: [CLK, MOSI, MISO, CS]
+    pin_ports: [u8; 4],
+}
+
+impl<'a> serprog::SpiCsGuard for SpiGuard<'a> {
+    type Spi = Spi<'a, embassy_stm32::mode::Async>;
+    type Cs = Output<'a>;
+
+    fn spi_cs(&mut self) -> (&mut Self::Spi, &mut Self::Cs) {
+        (&mut self.spi, &mut self.cs)
+    }
+}
+
+impl Drop for SpiGuard<'_> {
+    fn drop(&mut self) {
+        // Reset all SPI pins to analog/high-impedance state
+        for &pin_port in &self.pin_ports {
+            reset_pin_stm32(pin_port);
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn serprog_task(class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResources) -> ! {
+    let spi_provider = SpiProvider {
+        peripheral: r.peripheral,
+        clk: r.clk,
+        mosi: r.mosi,
+        miso: r.miso,
+        mosi_dma: r.mosi_dma,
+        miso_dma: r.miso_dma,
+        cs: r.cs,
+    };
+
+    let led = Output::new(r.led, Level::Low, Speed::Low);
+
+    serprog::run_loop::<_, _, _, USB_BUFFER_SIZE>(spi_provider, led, class).await
 }
 
 #[panic_handler]

--- a/picoprog/src/main.rs
+++ b/picoprog/src/main.rs
@@ -51,6 +51,7 @@ assign_resources! {
 }
 
 const FLASH_SIZE: usize = 2 * 1024 * 1024;
+const USB_BUFFER_SIZE: usize = 64;
 
 // According to Serial Flasher Protocol Specification - version 1
 
@@ -106,13 +107,13 @@ async fn main(spawner: Spawner) {
     let uart_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let serprog_class = {
         static STATE: StaticCell<State> = StaticCell::new();
         let state = STATE.init(State::new());
-        CdcAcmClass::new(&mut builder, state, 64)
+        CdcAcmClass::new(&mut builder, state, USB_BUFFER_SIZE.try_into().unwrap())
     };
 
     let usb = builder.build();
@@ -166,7 +167,13 @@ async fn serprog_task(class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResour
         spi.set_frequency(freq);
     };
 
-    let serprog = serprog::Serprog::new(spi, cs, led, class, Some(set_freq_cb));
+    let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
+        spi,
+        cs,
+        led,
+        class,
+        Some(set_freq_cb),
+    );
     serprog.run_loop().await
 }
 

--- a/picoprog/src/main.rs
+++ b/picoprog/src/main.rs
@@ -146,35 +146,112 @@ async fn usb_task(mut usb: CustomUsbDevice) -> ! {
     usb.run().await
 }
 
+/// Provider for SPI device that creates SPI on demand
+struct SpiProvider {
+    peripheral: Peri<'static, SPI0>,
+    clk: Peri<'static, peripherals::PIN_2>,
+    mosi: Peri<'static, peripherals::PIN_3>,
+    miso: Peri<'static, peripherals::PIN_4>,
+    mosi_dma: Peri<'static, peripherals::DMA_CH2>,
+    miso_dma: Peri<'static, peripherals::DMA_CH3>,
+    cs: Peri<'static, peripherals::PIN_5>,
+}
+
+/// Reset a GPIO pin to disconnected/high-impedance state on RP2040.
+/// This mimics what Flex::drop() does.
+fn reset_pin_rp2040(pin: u8) {
+    use embassy_rp::pac;
+    let io = pac::IO_BANK0;
+    let pads = pac::PADS_BANK0;
+
+    // Reset pad control to defaults
+    pads.gpio(pin as usize).write(|_| {});
+
+    // Set function select to NULL (disconnected) and reset overrides
+    io.gpio(pin as usize).ctrl().write(|w| {
+        w.set_funcsel(pac::io::vals::Gpio0ctrlFuncsel::NULL as _);
+        w.set_inover(pac::io::vals::Inover::NORMAL);
+        w.set_outover(pac::io::vals::Outover::NORMAL);
+    });
+}
+
+impl serprog::SpiDeviceProvider for SpiProvider {
+    type Guard<'a>
+        = SpiGuard<'a>
+    where
+        Self: 'a;
+
+    fn acquire(&mut self, freq_hz: u32) -> Self::Guard<'_> {
+        let mut config = SpiConfig::default();
+        config.frequency = freq_hz;
+
+        // Reborrow the peripherals - pins are now configured as SPI outputs
+        let spi = Spi::new(
+            self.peripheral.reborrow(),
+            self.clk.reborrow(),
+            self.mosi.reborrow(),
+            self.miso.reborrow(),
+            self.mosi_dma.reborrow(),
+            self.miso_dma.reborrow(),
+            config,
+        );
+        let cs = Output::new(self.cs.reborrow(), Level::High);
+
+        SpiGuard {
+            spi,
+            cs,
+            // Store pin numbers for reset on drop
+            pin_nums: [2, 3, 4, 5], // CLK=2, MOSI=3, MISO=4, CS=5
+        }
+    }
+}
+
+/// Guard that holds SPI and CS, resetting pins to high-impedance (disconnected) on drop.
+struct SpiGuard<'a> {
+    spi: Spi<'a, SPI0, embassy_rp::spi::Async>,
+    cs: Output<'a>,
+    /// Pin numbers to reset on drop: [CLK, MOSI, MISO, CS]
+    pin_nums: [u8; 4],
+}
+
+impl<'a> serprog::SpiCsGuard for SpiGuard<'a> {
+    type Spi = Spi<'a, SPI0, embassy_rp::spi::Async>;
+    type Cs = Output<'a>;
+
+    fn spi_cs(&mut self) -> (&mut Self::Spi, &mut Self::Cs) {
+        (&mut self.spi, &mut self.cs)
+    }
+}
+
+impl<'a> Drop for SpiGuard<'a> {
+    fn drop(&mut self) {
+        // Note: spi and cs are dropped automatically after this function returns.
+        // We reset pins here, but the actual SPI peripheral drop happens after.
+        // This is fine because we're just resetting GPIO config, and the SPI
+        // peripheral doesn't hold any GPIO state that would conflict.
+
+        // Reset all SPI pins to disconnected/high-impedance state
+        for &pin in &self.pin_nums {
+            reset_pin_rp2040(pin);
+        }
+    }
+}
+
 #[embassy_executor::task]
 async fn serprog_task(class: CdcAcmClass<'static, CustomUsbDriver>, r: SpiResources) -> ! {
-    let mut config = SpiConfig::default();
-    config.frequency = 12_000_000; // 12 MHz
-
-    let spi = Spi::new(
-        r.peripheral,
-        r.clk,
-        r.mosi,
-        r.miso,
-        r.mosi_dma,
-        r.miso_dma,
-        config,
-    );
-    let cs = Output::new(r.cs, Level::High);
-    let led = Output::new(r.led, Level::Low);
-
-    let set_freq_cb = move |spi: &mut Spi<'_, SPI0, embassy_rp::spi::Async>, freq| {
-        spi.set_frequency(freq);
+    let spi_provider = SpiProvider {
+        peripheral: r.peripheral,
+        clk: r.clk,
+        mosi: r.mosi,
+        miso: r.miso,
+        mosi_dma: r.mosi_dma,
+        miso_dma: r.miso_dma,
+        cs: r.cs,
     };
 
-    let serprog = serprog::Serprog::<_, _, _, _, _, USB_BUFFER_SIZE>::new(
-        spi,
-        cs,
-        led,
-        class,
-        Some(set_freq_cb),
-    );
-    serprog.run_loop().await
+    let led = Output::new(r.led, Level::Low);
+
+    serprog::run_loop::<_, _, _, USB_BUFFER_SIZE>(spi_provider, led, class).await
 }
 
 #[panic_handler]

--- a/serprog/Cargo.toml
+++ b/serprog/Cargo.toml
@@ -11,6 +11,7 @@ embassy-sync.workspace = true
 embedded-hal.workspace = true
 embedded-hal-async.workspace = true
 #log.workspace = true
+heapless.workspace = true
 defmt.workspace = true
 num_enum.workspace = true
 tock-registers.workspace = true

--- a/serprog/Cargo.toml
+++ b/serprog/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 embassy-usb.workspace = true
 embassy-futures.workspace = true
 embassy-sync.workspace = true
+embassy-time.workspace = true
 embedded-hal.workspace = true
 embedded-hal-async.workspace = true
 #log.workspace = true

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -7,6 +7,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::SpiBus;
+use heapless::Vec;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use tock_registers::register_bitfields;
 use tock_registers::LocalRegisterCopy;
@@ -341,48 +342,46 @@ where
             }
             SerprogCommand::OSpiOp => {
                 debug!("Received OSpiOp CMD");
-                let mut sdata = [0_u8; 64];
+
+                // Read directly into the first channel buffer
+                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, 64>::new() }; 4];
+                usb_rx_spi_tx_buf[0].resize(64, 0).ok();
                 self.transport
-                    .read(sdata.as_mut_slice())
+                    .read(usb_rx_spi_tx_buf[0].as_mut_slice())
                     .await
                     .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
 
-                let op_slen = le_u24_to_u32(&sdata[0..3]) as usize;
-                let op_rlen = le_u24_to_u32(&sdata[3..6]) as usize;
+                // Parse header from the first buffer
+                let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
+                let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
 
-                let mut usb_rx_spi_tx_buf = [([0u8; 64], 0); 4];
-                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, ([u8; 64], usize)> =
+                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
                     Channel::new(&mut usb_rx_spi_tx_buf);
                 let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
 
-                let mut usb_tx_spi_rx_buf = [([0u8; 64], 0); 8];
-                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, ([u8; 64], usize)> =
+                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, 64>::new() }; 8];
+                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
                 let usb_task = async |transport: &mut T,
-                                      mut sender: Sender<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
                                       sdata_size: usize,
-                                      sdata_0: [u8; 64],
-                                      mut receiver: Receiver<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
                                       rdata_size: usize|
                        -> Result<(), SerprogError> {
-                    // First block
+                    // First block - already contains header + initial data, send as-is
                     let mut data_to_read = sdata_size;
-                    {
-                        let (buf, size) = sender.send().await;
-                        let block_size = data_to_read.min(64 - 6);
-                        buf[..block_size].copy_from_slice(&sdata_0[6..6 + block_size]);
-                        *size = block_size;
-                        sender.send_done();
-                        data_to_read -= block_size;
-                    }
+                    let first_block_data_size = data_to_read.min(64 - 6);
+                    sender.send_done();
+                    data_to_read -= first_block_data_size;
 
                     while data_to_read > 0 {
                         let read_size = data_to_read.min(64);
-                        let (buf, size) = sender.send().await;
-                        *size = read_size;
-                        transport.read(&mut buf[..read_size]).await.map_err(|_| {
+                        let buf = sender.send().await;
+                        buf.clear();
+                        buf.resize(read_size, 0).ok();
+                        transport.read(buf.as_mut_slice()).await.map_err(|_| {
                             SerprogError::TransportRead("Error reading OSpiOp data")
                         })?;
                         sender.send_done();
@@ -395,21 +394,20 @@ where
 
                     let mut data_to_send = rdata_size;
                     while data_to_send > 0 {
-                        let (buf, size) = receiver.receive().await;
-                        let size = *size;
-                        transport.write(&buf[..size]).await.map_err(|_| {
+                        let buf = receiver.receive().await;
+                        transport.write(buf.as_slice()).await.map_err(|_| {
                             SerprogError::TransportWrite("Error writing SPI read data")
                         })?;
+                        data_to_send -= buf.len();
                         receiver.receive_done();
-                        data_to_send -= size;
                     }
                     Ok(())
                 };
 
                 let spi_task = async |spi: &mut SPI,
-                                      mut receiver: Receiver<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
                                       sdata_size: usize,
-                                      mut sender: Sender<NoopRawMutex, ([u8; 64], usize)>,
+                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
                                       rdata_size: usize,
                                       cs: &mut CS|
                        -> Result<(), SerprogError> {
@@ -420,22 +418,34 @@ where
                     cs.set_low()
                         .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
                     let mut data_to_write = sdata_size;
+                    let mut is_first = true;
                     while data_to_write > 0 {
-                        let (buf, size) = receiver.receive().await;
-                        data_to_write -= *size;
-                        spi.write(&buf[..*size])
+                        let buf = receiver.receive().await;
+                        let write_slice = if is_first {
+                            // First buffer: skip the 6-byte header
+                            is_first = false;
+                            let data_len = data_to_write.min(64 - 6);
+                            data_to_write -= data_len;
+                            &buf[6..6 + data_len]
+                        } else {
+                            // Subsequent buffers: use entire buffer
+                            data_to_write -= buf.len();
+                            buf.as_slice()
+                        };
+                        spi.write(write_slice)
                             .await
                             .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
                         receiver.receive_done();
                     }
                     let mut data_to_read = rdata_size;
                     while data_to_read > 0 {
-                        let (buf, size) = sender.send().await;
-                        let read_size = data_to_read.min(buf.len());
-                        spi.read(&mut buf[..read_size])
+                        let buf = sender.send().await;
+                        buf.clear();
+                        let read_size = data_to_read.min(64);
+                        buf.resize(read_size, 0).ok();
+                        spi.read(buf.as_mut_slice())
                             .await
                             .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
-                        *size = read_size;
                         sender.send_done();
                         data_to_read -= read_size;
                     }
@@ -454,7 +464,7 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    usb_task(&mut self.transport, usb_rx, op_slen, sdata, usb_tx, op_rlen),
+                    usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -207,6 +207,101 @@ pub struct Serprog<SPI, CS, LED, T: Transport, F> {
     freq_callback: Option<F>,
 }
 
+async fn ospiop_usb_task<T: Transport>(
+    transport: &mut T,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    sdata_size: usize,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    rdata_size: usize,
+) -> Result<(), SerprogError> {
+    // First block - already contains header + initial data, send as-is
+    let mut data_to_read = sdata_size;
+    let first_block_data_size = data_to_read.min(64 - 6);
+    sender.send_done();
+    data_to_read -= first_block_data_size;
+
+    while data_to_read > 0 {
+        let read_size = data_to_read.min(64);
+        let buf = sender.send().await;
+        buf.clear();
+        buf.resize(read_size, 0).ok();
+        transport
+            .read(buf.as_mut_slice())
+            .await
+            .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+        sender.send_done();
+        data_to_read -= read_size;
+    }
+    transport
+        .write(&[S_ACK])
+        .await
+        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
+
+    let mut data_to_send = rdata_size;
+    while data_to_send > 0 {
+        let buf = receiver.receive().await;
+        transport
+            .write(buf.as_slice())
+            .await
+            .map_err(|_| SerprogError::TransportWrite("Error writing SPI read data"))?;
+        data_to_send -= buf.len();
+        receiver.receive_done();
+    }
+    Ok(())
+}
+
+async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
+    spi: &mut SPI,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    sdata_size: usize,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    rdata_size: usize,
+    cs: &mut CS,
+) -> Result<(), SerprogError> {
+    spi.flush()
+        .await
+        .map_err(|_| SerprogError::SpiFlush("Error flushing SPI before transfer"))?;
+
+    cs.set_low()
+        .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
+    let mut data_to_write = sdata_size;
+    let mut is_first = true;
+    while data_to_write > 0 {
+        let buf = receiver.receive().await;
+        let write_slice = if is_first {
+            // First buffer: skip the 6-byte header
+            is_first = false;
+            let data_len = data_to_write.min(64 - 6);
+            data_to_write -= data_len;
+            &buf[6..6 + data_len]
+        } else {
+            // Subsequent buffers: use entire buffer
+            data_to_write -= buf.len();
+            buf.as_slice()
+        };
+        spi.write(write_slice)
+            .await
+            .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
+        receiver.receive_done();
+    }
+    let mut data_to_read = rdata_size;
+    while data_to_read > 0 {
+        let buf = sender.send().await;
+        buf.clear();
+        let read_size = data_to_read.min(64);
+        buf.resize(read_size, 0).ok();
+        spi.read(buf.as_mut_slice())
+            .await
+            .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
+        sender.send_done();
+        data_to_read -= read_size;
+    }
+    cs.set_high()
+        .map_err(|_| SerprogError::CsSetHigh("Error setting CS high"))?;
+    debug!("OSpiOp CMD done");
+    Ok(())
+}
+
 impl<SPI, CS, LED, T, F> Serprog<SPI, CS, LED, T, F>
 where
     SPI: SpiBus<u8>,
@@ -364,99 +459,8 @@ where
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
-                let usb_task = async |transport: &mut T,
-                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
-                                      sdata_size: usize,
-                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
-                                      rdata_size: usize|
-                       -> Result<(), SerprogError> {
-                    // First block - already contains header + initial data, send as-is
-                    let mut data_to_read = sdata_size;
-                    let first_block_data_size = data_to_read.min(64 - 6);
-                    sender.send_done();
-                    data_to_read -= first_block_data_size;
-
-                    while data_to_read > 0 {
-                        let read_size = data_to_read.min(64);
-                        let buf = sender.send().await;
-                        buf.clear();
-                        buf.resize(read_size, 0).ok();
-                        transport.read(buf.as_mut_slice()).await.map_err(|_| {
-                            SerprogError::TransportRead("Error reading OSpiOp data")
-                        })?;
-                        sender.send_done();
-                        data_to_read -= read_size;
-                    }
-                    transport
-                        .write(&[S_ACK])
-                        .await
-                        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
-
-                    let mut data_to_send = rdata_size;
-                    while data_to_send > 0 {
-                        let buf = receiver.receive().await;
-                        transport.write(buf.as_slice()).await.map_err(|_| {
-                            SerprogError::TransportWrite("Error writing SPI read data")
-                        })?;
-                        data_to_send -= buf.len();
-                        receiver.receive_done();
-                    }
-                    Ok(())
-                };
-
-                let spi_task = async |spi: &mut SPI,
-                                      mut receiver: Receiver<NoopRawMutex, Vec<u8, 64>>,
-                                      sdata_size: usize,
-                                      mut sender: Sender<NoopRawMutex, Vec<u8, 64>>,
-                                      rdata_size: usize,
-                                      cs: &mut CS|
-                       -> Result<(), SerprogError> {
-                    spi.flush().await.map_err(|_| {
-                        SerprogError::SpiFlush("Error flushing SPI before transfer")
-                    })?;
-
-                    cs.set_low()
-                        .map_err(|_| SerprogError::CsSetLow("Error setting CS low"))?;
-                    let mut data_to_write = sdata_size;
-                    let mut is_first = true;
-                    while data_to_write > 0 {
-                        let buf = receiver.receive().await;
-                        let write_slice = if is_first {
-                            // First buffer: skip the 6-byte header
-                            is_first = false;
-                            let data_len = data_to_write.min(64 - 6);
-                            data_to_write -= data_len;
-                            &buf[6..6 + data_len]
-                        } else {
-                            // Subsequent buffers: use entire buffer
-                            data_to_write -= buf.len();
-                            buf.as_slice()
-                        };
-                        spi.write(write_slice)
-                            .await
-                            .map_err(|_| SerprogError::SpiTransfer("Error writing OSpiOp data"))?;
-                        receiver.receive_done();
-                    }
-                    let mut data_to_read = rdata_size;
-                    while data_to_read > 0 {
-                        let buf = sender.send().await;
-                        buf.clear();
-                        let read_size = data_to_read.min(64);
-                        buf.resize(read_size, 0).ok();
-                        spi.read(buf.as_mut_slice())
-                            .await
-                            .map_err(|_| SerprogError::SpiTransfer("Error reading OSpiOp data"))?;
-                        sender.send_done();
-                        data_to_read -= read_size;
-                    }
-                    cs.set_high()
-                        .map_err(|_| SerprogError::CsSetHigh("Error setting CS high"))?;
-                    debug!("OSpiOp CMD done");
-                    Ok(())
-                };
-
                 let (spi_res, usb_res) = block_on(join(
-                    spi_task(
+                    ospiop_spi_task(
                         &mut self.spi,
                         spi_tx,
                         op_slen,
@@ -464,7 +468,7 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
+                    ospiop_usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -199,7 +199,7 @@ impl QCmdMapResponse {
     }
 }
 
-pub struct Serprog<SPI, CS, LED, T: Transport, F> {
+pub struct Serprog<SPI, CS, LED, T: Transport<TRANSFER_SIZE>, F, const TRANSFER_SIZE: usize> {
     spi: SPI,
     cs: CS,
     led: LED,
@@ -207,21 +207,21 @@ pub struct Serprog<SPI, CS, LED, T: Transport, F> {
     freq_callback: Option<F>,
 }
 
-async fn ospiop_usb_task<T: Transport>(
+async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize>(
     transport: &mut T,
-    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     sdata_size: usize,
-    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     rdata_size: usize,
 ) -> Result<(), SerprogError> {
     // First block - already contains header + initial data, send as-is
     let mut data_to_read = sdata_size;
-    let first_block_data_size = data_to_read.min(64 - 6);
+    let first_block_data_size = data_to_read.min(TRANSFER_SIZE - 6);
     sender.send_done();
     data_to_read -= first_block_data_size;
 
     while data_to_read > 0 {
-        let read_size = data_to_read.min(64);
+        let read_size = data_to_read.min(TRANSFER_SIZE);
         let buf = sender.send().await;
         buf.clear();
         buf.resize(read_size, 0).ok();
@@ -250,11 +250,11 @@ async fn ospiop_usb_task<T: Transport>(
     Ok(())
 }
 
-async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
+async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: usize>(
     spi: &mut SPI,
-    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut receiver: Receiver<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     sdata_size: usize,
-    mut sender: Sender<'_, NoopRawMutex, Vec<u8, 64>>,
+    mut sender: Sender<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>>,
     rdata_size: usize,
     cs: &mut CS,
 ) -> Result<(), SerprogError> {
@@ -271,7 +271,7 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
         let write_slice = if is_first {
             // First buffer: skip the 6-byte header
             is_first = false;
-            let data_len = data_to_write.min(64 - 6);
+            let data_len = data_to_write.min(TRANSFER_SIZE - 6);
             data_to_write -= data_len;
             &buf[6..6 + data_len]
         } else {
@@ -288,7 +288,7 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
     while data_to_read > 0 {
         let buf = sender.send().await;
         buf.clear();
-        let read_size = data_to_read.min(64);
+        let read_size = data_to_read.min(TRANSFER_SIZE);
         buf.resize(read_size, 0).ok();
         spi.read(buf.as_mut_slice())
             .await
@@ -302,12 +302,12 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin>(
     Ok(())
 }
 
-impl<SPI, CS, LED, T, F> Serprog<SPI, CS, LED, T, F>
+impl<SPI, CS, LED, T, F, const TRANSFER_SIZE: usize> Serprog<SPI, CS, LED, T, F, TRANSFER_SIZE>
 where
     SPI: SpiBus<u8>,
     CS: OutputPin,
     LED: OutputPin,
-    T: Transport,
+    T: Transport<TRANSFER_SIZE>,
     F: FnMut(&mut SPI, u32) + Send + Sync,
 {
     pub fn new(spi: SPI, cs: CS, led: LED, transport: T, freq_callback: Option<F>) -> Self {
@@ -320,7 +320,11 @@ where
         }
     }
 
-    pub async fn run_loop(mut self) -> ! {
+    pub async fn run_loop(mut self) -> !
+    where
+        CS::Error: core::fmt::Debug,
+        LED::Error: core::fmt::Debug,
+    {
         let mut buf = [0; 1];
 
         loop {
@@ -439,8 +443,8 @@ where
                 debug!("Received OSpiOp CMD");
 
                 // Read directly into the first channel buffer
-                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, 64>::new() }; 4];
-                usb_rx_spi_tx_buf[0].resize(64, 0).ok();
+                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
+                usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
                 self.transport
                     .read(usb_rx_spi_tx_buf[0].as_mut_slice())
                     .await
@@ -450,17 +454,17 @@ where
                 let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
                 let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
 
-                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
+                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
                     Channel::new(&mut usb_rx_spi_tx_buf);
                 let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
 
-                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, 64>::new() }; 8];
-                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, 64>> =
+                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 8];
+                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
                     Channel::new(&mut usb_tx_spi_rx_buf);
                 let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
 
                 let (spi_res, usb_res) = block_on(join(
-                    ospiop_spi_task(
+                    ospiop_spi_task::<_, _, TRANSFER_SIZE>(
                         &mut self.spi,
                         spi_tx,
                         op_slen,
@@ -468,7 +472,13 @@ where
                         op_rlen,
                         &mut self.cs,
                     ),
-                    ospiop_usb_task(&mut self.transport, usb_rx, op_slen, usb_tx, op_rlen),
+                    ospiop_usb_task::<_, TRANSFER_SIZE>(
+                        &mut self.transport,
+                        usb_rx,
+                        op_slen,
+                        usb_tx,
+                        op_rlen,
+                    ),
                 ));
                 if let Err(spi_err) = spi_res {
                     self.transport

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
 use core::result::Result::{Err, Ok};
-use embassy_futures::{block_on, join::join};
+use embassy_futures::join::join;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
+use embassy_time::{with_timeout, Duration};
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::SpiBus;
 use heapless::Vec;
@@ -22,6 +23,7 @@ pub mod transport;
 pub enum SerprogError {
     TransportRead(&'static str),
     TransportWrite(&'static str),
+    Timeout(&'static str),
     SpiTransfer(&'static str),
     SpiFlush(&'static str),
     CsSetLow(&'static str),
@@ -285,28 +287,32 @@ async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize
 
     while data_to_read > 0 {
         let read_size = data_to_read.min(TRANSFER_SIZE);
-        let buf = sender.send().await;
+        let buf = with_timeout(SPIOP_TIMEOUT, sender.send())
+            .await
+            .map_err(|_| SerprogError::Timeout("Timeout allocating buffer for USB read"))?;
         buf.clear();
         buf.resize(read_size, 0).ok();
-        transport
-            .read(buf.as_mut_slice())
+        with_timeout(SPIOP_TIMEOUT, transport.read(buf.as_mut_slice()))
             .await
-            .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+            .map_err(|_| SerprogError::Timeout("Timeout reading OSpiOp data from host"))?
+            .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data from host"))?;
         sender.send_done();
         data_to_read -= read_size;
     }
-    transport
-        .write(&[S_ACK])
+    with_timeout(SPIOP_TIMEOUT, transport.write(&[S_ACK]))
         .await
-        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
+        .map_err(|_| SerprogError::Timeout("Timeout writing ACK to host"))?
+        .map_err(|_| SerprogError::TransportWrite("Error writing ACK to host"))?;
 
     let mut data_to_send = rdata_size;
     while data_to_send > 0 {
-        let buf = receiver.receive().await;
-        transport
-            .write(buf.as_slice())
+        let buf = with_timeout(SPIOP_TIMEOUT, receiver.receive())
             .await
-            .map_err(|_| SerprogError::TransportWrite("Error writing SPI read data"))?;
+            .map_err(|_| SerprogError::Timeout("Timeout waiting for SPI read data"))?;
+        with_timeout(SPIOP_TIMEOUT, transport.write(buf.as_slice()))
+            .await
+            .map_err(|_| SerprogError::Timeout("Timeout writing SPI read data to host"))?
+            .map_err(|_| SerprogError::TransportWrite("Error writing SPI read data to host"))?;
         data_to_send -= buf.len();
         receiver.receive_done();
     }
@@ -330,7 +336,12 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: us
     let mut data_to_write = sdata_size;
     let mut is_first = true;
     while data_to_write > 0 {
-        let buf = receiver.receive().await;
+        let buf = with_timeout(SPIOP_TIMEOUT, receiver.receive())
+            .await
+            .map_err(|_| SerprogError::Timeout("Timeout writing ACK to host"))?;
+        //        .map_err(|_| SerprogError::TransportWrite("Error writing ACK to host"))?;
+
+        //        let buf = receiver.receive().await;
         let write_slice = if is_first {
             // First buffer: skip the 6-byte header
             is_first = false;
@@ -349,7 +360,11 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: us
     }
     let mut data_to_read = rdata_size;
     while data_to_read > 0 {
-        let buf = sender.send().await;
+        let buf = with_timeout(SPIOP_TIMEOUT, sender.send())
+            .await
+            .map_err(|_| SerprogError::Timeout("Timeout writing ACK to host"))?;
+
+        //        let buf = sender.send().await;
         buf.clear();
         let read_size = data_to_read.min(TRANSFER_SIZE);
         buf.resize(read_size, 0).ok();
@@ -367,6 +382,14 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: us
 
 /// Default SPI frequency in Hz (12 MHz)
 const DEFAULT_SPI_FREQ_HZ: u32 = 12_000_000;
+
+/// Timeout for SPI operations (3 seconds)
+/// This should be long enough for large flash operations but short enough
+/// to detect when the host has been halted or the SPI device is hung
+const SPIOP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Timeout for simple command responses (5 seconds)
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Main serprog loop that handles commands from the transport.
 ///
@@ -402,7 +425,15 @@ where
         )
         .await
         {
-            error!("Command error: {:?}", e);
+            match e {
+                SerprogError::Timeout(_) => {
+                    error!("Timeout detected, host may have disconnected: {:?}", e);
+                    // Continue to main loop to wait for next command
+                }
+                _ => {
+                    error!("Command error: {:?}", e);
+                }
+            }
         }
     }
 }
@@ -422,95 +453,148 @@ where
     match cmd {
         SerprogCommand::Nop => {
             debug!("Received Nop CMD");
-            transport
-                .write(&[S_ACK])
+            let operation = async {
+                transport
+                    .write(&[S_ACK])
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing ACK"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing ACK"))?;
+                .map_err(|_| SerprogError::Timeout("Nop command timed out"))??;
             Ok(())
         }
         SerprogCommand::QIface => {
             debug!("Received QIface CMD");
-            let response = QIfaceResponse {
-                ack: S_ACK,
-                version: U16::new(1),
+            let operation = async {
+                let response = QIfaceResponse {
+                    ack: S_ACK,
+                    version: U16::new(1),
+                };
+                transport
+                    .write(response.as_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QIface response"))?;
+                Ok(())
             };
-            transport
-                .write(response.as_bytes())
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QIface response"))?;
+                .map_err(|_| SerprogError::Timeout("QIface command timed out"))??;
             Ok(())
         }
         SerprogCommand::QCmdMap => {
             debug!("Received QCmdMap CMD");
-            let response = QCmdMapResponse::new();
-            transport
-                .write(response.as_bytes())
+            let operation = async {
+                let response = QCmdMapResponse::new();
+                transport
+                    .write(response.as_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QCmdMap response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QCmdMap response"))?;
+                .map_err(|_| SerprogError::Timeout("QCmdMap command timed out"))??;
             Ok(())
         }
         SerprogCommand::QPgmName => {
             debug!("Received QPgmName CMD");
-            let response = QPgmNameResponse::new("Picoprog");
-            transport
-                .write(response.as_bytes())
+            let operation = async {
+                let response = QPgmNameResponse::new("Picoprog");
+                transport
+                    .write(response.as_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QPgmName response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QPgmName response"))?;
+                .map_err(|_| SerprogError::Timeout("QPgmName command timed out"))??;
             Ok(())
         }
         SerprogCommand::QSerBuf => {
             debug!("Received QSerBuf CMD");
-            transport
-                .write(&[S_ACK, 0xFF, 0xFF])
+            let operation = async {
+                transport
+                    .write(&[S_ACK, 0xFF, 0xFF])
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QSerBuf response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QSerBuf response"))?;
+                .map_err(|_| SerprogError::Timeout("QSerBuf command timed out"))??;
             Ok(())
         }
         SerprogCommand::QWrNMaxLen | SerprogCommand::QRdNMaxLen => {
             debug!("Received QWrNMaxLen/QRdNMaxLen CMD");
-            let response = QMaxLenResponse::new(MAX_BUFFER_SIZE);
-            transport
-                .write(response.as_bytes())
+            let operation = async {
+                let response = QMaxLenResponse::new(MAX_BUFFER_SIZE);
+                transport
+                    .write(response.as_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QMaxLen response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QMaxLen response"))?;
+                .map_err(|_| SerprogError::Timeout("QMaxLen command timed out"))??;
             Ok(())
         }
         SerprogCommand::QBustype => {
             debug!("Received QBustype CMD");
-            transport
-                .write(&[S_ACK, 0x08])
+            let operation = async {
+                transport
+                    .write(&[S_ACK, 0x08])
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing QBustype response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing QBustype response"))?;
+                .map_err(|_| SerprogError::Timeout("QBustype command timed out"))??;
             Ok(())
         }
         SerprogCommand::SyncNop => {
             debug!("Received SyncNop CMD");
-            transport
-                .write(&[S_NAK, S_ACK])
+            let operation = async {
+                transport
+                    .write(&[S_NAK, S_ACK])
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing SyncNop response"))?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing SyncNop response"))?;
+                .map_err(|_| SerprogError::Timeout("SyncNop command timed out"))??;
             Ok(())
         }
         SerprogCommand::SBustype => {
             debug!("Received SBustype CMD");
-            let mut buf = [0u8; 1];
-            transport
-                .read(&mut buf)
+            let operation =
+                async {
+                    let mut buf = [0u8; 1];
+                    transport
+                        .read(&mut buf)
+                        .await
+                        .map_err(|_| SerprogError::TransportRead("Error reading SBustype data"))?;
+                    if buf[0] == 0x08 {
+                        debug!("Received SBustype 'SPI'");
+                        transport.write(&[S_ACK]).await.map_err(|_| {
+                            SerprogError::TransportWrite("Error writing SBustype ACK")
+                        })?;
+                    } else {
+                        debug!("Received unknown SBustype");
+                        transport.write(&[S_NAK]).await.map_err(|_| {
+                            SerprogError::TransportWrite("Error writing SBustype NAK")
+                        })?;
+                    }
+                    Ok(())
+                };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportRead("Error reading SBustype data"))?;
-            if buf[0] == 0x08 {
-                debug!("Received SBustype 'SPI'");
-                transport
-                    .write(&[S_ACK])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
-            } else {
-                debug!("Received unknown SBustype");
-                transport
-                    .write(&[S_NAK])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing SBustype NAK"))?;
-            }
+                .map_err(|_| SerprogError::Timeout("SBustype command timed out"))??;
             Ok(())
         }
         SerprogCommand::OSpiOp => {
@@ -519,10 +603,13 @@ where
             // Read directly into the first channel buffer
             let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
             usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
-            transport
-                .read(usb_rx_spi_tx_buf[0].as_mut_slice())
-                .await
-                .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+            with_timeout(
+                SPIOP_TIMEOUT,
+                transport.read(usb_rx_spi_tx_buf[0].as_mut_slice()),
+            )
+            .await
+            .map_err(|_| SerprogError::Timeout("Timeout reading OSpiOp header"))?
+            .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp header"))?;
 
             // Parse header from the first buffer
             let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
@@ -542,81 +629,104 @@ where
             let mut spi_guard = spi_provider.acquire(*spi_freq_hz);
             let (spi, cs) = spi_guard.spi_cs();
 
-            let (spi_res, usb_res) = block_on(join(
+            // Run both tasks concurrently
+            // If USB task times out, it returns an error and the SPI task will
+            // also complete (channel operations will unblock when counterpart completes)
+            let (spi_res, usb_res) = join(
                 ospiop_spi_task::<_, _, TRANSFER_SIZE>(spi, spi_tx, op_slen, spi_rx, op_rlen, cs),
                 ospiop_usb_task::<_, TRANSFER_SIZE>(transport, usb_rx, op_slen, usb_tx, op_rlen),
-            ));
+            )
+            .await;
 
             // Guard is dropped here, releasing the SPI pins back to input mode
             drop(spi_guard);
 
+            // Check USB error first (timeout detection happens here)
+            usb_res?;
+
+            // Then check SPI error
             if let Err(spi_err) = spi_res {
-                transport
-                    .write(&[S_NAK])
+                with_timeout(SPIOP_TIMEOUT, transport.write(&[S_NAK]))
                     .await
-                    .map_err(|_| SerprogError::TransportWrite("Failed to report SPI failed"))?;
+                    .map_err(|_| SerprogError::Timeout("Timeout reporting SPI error to host"))?
+                    .map_err(|_| SerprogError::TransportWrite("Failed to report SPI error"))?;
                 return Err(spi_err);
             }
-            usb_res?;
 
             Ok(())
         }
         SerprogCommand::SSpiFreq => {
             debug!("Received SSpiFreq CMD");
-            let mut request = SSpiFreqRequest::new_zeroed();
-            transport
-                .read(request.as_mut_bytes())
-                .await
-                .map_err(|_| SerprogError::TransportRead("Error reading SSpiFreq data"))?;
+            let operation = async {
+                let mut request = SSpiFreqRequest::new_zeroed();
+                transport
+                    .read(request.as_mut_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportRead("Error reading SSpiFreq data"))?;
 
-            // Store the requested frequency for use when acquiring SPI
-            let requested_freq = request.freq.get();
-            *spi_freq_hz = requested_freq;
+                // Store the requested frequency for use when acquiring SPI
+                let requested_freq = request.freq.get();
+                *spi_freq_hz = requested_freq;
 
-            debug!("Setting SPI frequency: {:?}", requested_freq);
+                debug!("Setting SPI frequency: {:?}", requested_freq);
 
-            // Create and send response
-            let response = SSpiFreqResponse {
-                ack: S_ACK,
-                freq: U32::new(requested_freq),
+                // Create and send response
+                let response = SSpiFreqResponse {
+                    ack: S_ACK,
+                    freq: U32::new(requested_freq),
+                };
+
+                transport
+                    .write(response.as_bytes())
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing SSpiFreq response"))?;
+
+                Ok(())
             };
-
-            transport
-                .write(response.as_bytes())
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing SSpiFreq response"))?;
-
+                .map_err(|_| SerprogError::Timeout("SSpiFreq command timed out"))??;
             Ok(())
         }
         SerprogCommand::SPinState => {
             debug!("Received SPinState CMD");
-            let mut buf = [0u8; 1];
-            transport
-                .read(&mut buf)
-                .await
-                .map_err(|_| SerprogError::TransportRead("Error reading SPinState data"))?;
-            let led = led_provider.led();
-            if buf[0] == 0 {
-                led.set_low()
-                    .map_err(|_| SerprogError::LedSetLow("Error setting LED low"))?;
-            } else {
-                led.set_high()
-                    .map_err(|_| SerprogError::LedSetHigh("Error setting LED high"))?;
-            }
-            transport
-                .write(&[S_ACK])
-                .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing SPinState ACK"))?;
+            let operation = async {
+                let mut buf = [0u8; 1];
+                transport
+                    .read(&mut buf)
+                    .await
+                    .map_err(|_| SerprogError::TransportRead("Error reading SPinState data"))?;
+                let led = led_provider.led();
+                if buf[0] == 0 {
+                    led.set_low()
+                        .map_err(|_| SerprogError::LedSetLow("Error setting LED low"))?;
+                } else {
+                    led.set_high()
+                        .map_err(|_| SerprogError::LedSetHigh("Error setting LED high"))?;
+                }
+                transport
+                    .write(&[S_ACK])
+                    .await
+                    .map_err(|_| SerprogError::TransportWrite("Error writing SPinState ACK"))?;
 
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
+                .await
+                .map_err(|_| SerprogError::Timeout("SPinState command timed out"))??;
             Ok(())
         }
         _ => {
             debug!("Received unknown CMD");
-            transport
-                .write(&[S_NAK])
+            let operation = async {
+                transport.write(&[S_NAK]).await.map_err(|_| {
+                    SerprogError::TransportWrite("Error writing unknown command NAK")
+                })?;
+                Ok(())
+            };
+            with_timeout(COMMAND_TIMEOUT, operation)
                 .await
-                .map_err(|_| SerprogError::TransportWrite("Error writing unknown command NAK"))?;
-
+                .map_err(|_| SerprogError::Timeout("Unknown command response timed out"))??;
             Ok(())
         }
     }

--- a/serprog/src/lib.rs
+++ b/serprog/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-use core::convert::From;
 use core::result::Result::{Err, Ok};
 use embassy_futures::{block_on, join::join};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -163,7 +162,7 @@ register_bitfields! [u32,
 ];
 
 impl QCmdMapResponse {
-    fn new(has_freq_callback: bool) -> Self {
+    fn new() -> Self {
         let mut response = Self {
             ack: S_ACK,
             map: [0; 4],
@@ -172,7 +171,7 @@ impl QCmdMapResponse {
 
         // Set supported commands using tock-registers
         let mut cmdmap = LocalRegisterCopy::<u32, Commands::Register>::new(0);
-        let mut cmd_flags = Commands::Nop::SET
+        let cmd_flags = Commands::Nop::SET
             + Commands::QIface::SET
             + Commands::QCmdMap::SET
             + Commands::QPgmName::SET
@@ -183,11 +182,8 @@ impl QCmdMapResponse {
             + Commands::QRdNMaxLen::SET
             + Commands::OSpiOp::SET
             + Commands::SBustype::SET
-            + Commands::SPinState::SET;
-
-        if has_freq_callback {
-            cmd_flags += Commands::SSpiFreq::SET;
-        }
+            + Commands::SPinState::SET
+            + Commands::SSpiFreq::SET;
 
         cmdmap.modify(cmd_flags);
 
@@ -199,12 +195,79 @@ impl QCmdMapResponse {
     }
 }
 
-pub struct Serprog<SPI, CS, LED, T: Transport<TRANSFER_SIZE>, F, const TRANSFER_SIZE: usize> {
-    spi: SPI,
-    cs: CS,
-    led: LED,
-    transport: T,
-    freq_callback: Option<F>,
+/// Trait for a guard that provides access to SPI and CS.
+/// When the guard is dropped, the pins should be set back to input mode.
+pub trait SpiCsGuard {
+    type Spi: SpiBus<u8>;
+    type Cs: OutputPin;
+
+    /// Get mutable references to the SPI bus and CS pin.
+    fn spi_cs(&mut self) -> (&mut Self::Spi, &mut Self::Cs);
+}
+
+/// Generic implementation of `SpiCsGuard` that holds an SPI bus and CS pin.
+///
+/// **Important**: This basic implementation does NOT reset pins to input/high-impedance
+/// mode when dropped. Embassy's SPI and Output types do not automatically reset pins
+/// on drop. If you need pin cleanup (recommended to avoid interfering with the target
+/// board), implement a custom guard that resets pins in its `Drop` implementation.
+///
+/// See the picoprog and bluepill-prog examples for how to properly reset pins on drop.
+pub struct SpiCsGuardImpl<SPI, CS> {
+    pub spi: SPI,
+    pub cs: CS,
+}
+
+impl<SPI, CS> SpiCsGuardImpl<SPI, CS> {
+    /// Create a new guard.
+    ///
+    /// **Warning**: Pins will NOT be automatically reset to input mode when dropped.
+    /// Consider implementing a custom guard if you need pin cleanup.
+    pub fn new(spi: SPI, cs: CS) -> Self {
+        Self { spi, cs }
+    }
+}
+
+impl<SPI: SpiBus<u8>, CS: OutputPin> SpiCsGuard for SpiCsGuardImpl<SPI, CS> {
+    type Spi = SPI;
+    type Cs = CS;
+
+    fn spi_cs(&mut self) -> (&mut Self::Spi, &mut Self::Cs) {
+        (&mut self.spi, &mut self.cs)
+    }
+}
+
+/// Trait for providing SPI device and CS pin on demand.
+/// The SPI device is created when needed and the pins are released (set back to input)
+/// when the returned guard is dropped.
+pub trait SpiDeviceProvider {
+    type Guard<'a>: SpiCsGuard
+    where
+        Self: 'a;
+
+    /// Acquire the SPI device and CS pin. The pins should be configured as outputs.
+    /// When the returned guard is dropped, the pins should be set back to input mode.
+    ///
+    /// # Arguments
+    /// * `freq_hz` - The requested SPI clock frequency in Hz.
+    fn acquire(&mut self, freq_hz: u32) -> Self::Guard<'_>;
+}
+
+/// Trait for providing an LED indicator
+pub trait LedProvider {
+    type Led: OutputPin;
+
+    fn led(&mut self) -> &mut Self::Led;
+}
+
+/// Blanket implementation of `LedProvider` for any `OutputPin`.
+/// This allows passing an `Output` directly without a wrapper struct.
+impl<L: OutputPin> LedProvider for L {
+    type Led = L;
+
+    fn led(&mut self) -> &mut Self::Led {
+        self
+    }
 }
 
 async fn ospiop_usb_task<T: Transport<TRANSFER_SIZE>, const TRANSFER_SIZE: usize>(
@@ -302,257 +365,259 @@ async fn ospiop_spi_task<SPI: SpiBus<u8>, CS: OutputPin, const TRANSFER_SIZE: us
     Ok(())
 }
 
-impl<SPI, CS, LED, T, F, const TRANSFER_SIZE: usize> Serprog<SPI, CS, LED, T, F, TRANSFER_SIZE>
+/// Default SPI frequency in Hz (12 MHz)
+const DEFAULT_SPI_FREQ_HZ: u32 = 12_000_000;
+
+/// Main serprog loop that handles commands from the transport.
+///
+/// This function runs indefinitely, processing serprog commands.
+/// SPI pins are only configured as outputs during actual SPI operations
+/// and are released (via the SpiDeviceProvider's Drop impl) after each operation.
+pub async fn run_loop<S, L, T, const TRANSFER_SIZE: usize>(
+    mut spi_provider: S,
+    mut led_provider: L,
+    mut transport: T,
+) -> !
 where
-    SPI: SpiBus<u8>,
-    CS: OutputPin,
-    LED: OutputPin,
+    S: SpiDeviceProvider,
+    L: LedProvider,
     T: Transport<TRANSFER_SIZE>,
-    F: FnMut(&mut SPI, u32) + Send + Sync,
 {
-    pub fn new(spi: SPI, cs: CS, led: LED, transport: T, freq_callback: Option<F>) -> Self {
-        Self {
-            spi,
-            cs,
-            led,
-            transport,
-            freq_callback,
+    let mut buf = [0; 1];
+    let mut spi_freq_hz = DEFAULT_SPI_FREQ_HZ;
+
+    loop {
+        if transport.read(&mut buf).await.is_err() {
+            error!("Read error in main loop");
+            continue;
+        }
+
+        let cmd = SerprogCommand::try_from(buf[0]).unwrap_or(SerprogCommand::Nop);
+        if let Err(e) = handle_command::<_, _, _, TRANSFER_SIZE>(
+            &mut spi_provider,
+            &mut led_provider,
+            &mut transport,
+            cmd,
+            &mut spi_freq_hz,
+        )
+        .await
+        {
+            error!("Command error: {:?}", e);
         }
     }
+}
 
-    pub async fn run_loop(mut self) -> !
-    where
-        CS::Error: core::fmt::Debug,
-        LED::Error: core::fmt::Debug,
-    {
-        let mut buf = [0; 1];
-
-        loop {
-            if self.transport.read(&mut buf).await.is_err() {
-                error!("Read error in main loop");
-                continue;
-            }
-
-            let cmd = SerprogCommand::try_from(buf[0]).unwrap_or(SerprogCommand::Nop);
-            if let Err(e) = self.handle_command(cmd).await {
-                error!("Command error: {:?}", e);
-            }
+async fn handle_command<S, L, T, const TRANSFER_SIZE: usize>(
+    spi_provider: &mut S,
+    led_provider: &mut L,
+    transport: &mut T,
+    cmd: SerprogCommand,
+    spi_freq_hz: &mut u32,
+) -> Result<(), SerprogError>
+where
+    S: SpiDeviceProvider,
+    L: LedProvider,
+    T: Transport<TRANSFER_SIZE>,
+{
+    match cmd {
+        SerprogCommand::Nop => {
+            debug!("Received Nop CMD");
+            transport
+                .write(&[S_ACK])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing ACK"))?;
+            Ok(())
         }
-    }
-
-    async fn handle_command(&mut self, cmd: SerprogCommand) -> Result<(), SerprogError>
-    where
-        CS::Error: core::fmt::Debug,
-        LED::Error: core::fmt::Debug,
-    {
-        match cmd {
-            SerprogCommand::Nop => {
-                debug!("Received Nop CMD");
-                self.transport
+        SerprogCommand::QIface => {
+            debug!("Received QIface CMD");
+            let response = QIfaceResponse {
+                ack: S_ACK,
+                version: U16::new(1),
+            };
+            transport
+                .write(response.as_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QIface response"))?;
+            Ok(())
+        }
+        SerprogCommand::QCmdMap => {
+            debug!("Received QCmdMap CMD");
+            let response = QCmdMapResponse::new();
+            transport
+                .write(response.as_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QCmdMap response"))?;
+            Ok(())
+        }
+        SerprogCommand::QPgmName => {
+            debug!("Received QPgmName CMD");
+            let response = QPgmNameResponse::new("Picoprog");
+            transport
+                .write(response.as_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QPgmName response"))?;
+            Ok(())
+        }
+        SerprogCommand::QSerBuf => {
+            debug!("Received QSerBuf CMD");
+            transport
+                .write(&[S_ACK, 0xFF, 0xFF])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QSerBuf response"))?;
+            Ok(())
+        }
+        SerprogCommand::QWrNMaxLen | SerprogCommand::QRdNMaxLen => {
+            debug!("Received QWrNMaxLen/QRdNMaxLen CMD");
+            let response = QMaxLenResponse::new(MAX_BUFFER_SIZE);
+            transport
+                .write(response.as_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QMaxLen response"))?;
+            Ok(())
+        }
+        SerprogCommand::QBustype => {
+            debug!("Received QBustype CMD");
+            transport
+                .write(&[S_ACK, 0x08])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing QBustype response"))?;
+            Ok(())
+        }
+        SerprogCommand::SyncNop => {
+            debug!("Received SyncNop CMD");
+            transport
+                .write(&[S_NAK, S_ACK])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing SyncNop response"))?;
+            Ok(())
+        }
+        SerprogCommand::SBustype => {
+            debug!("Received SBustype CMD");
+            let mut buf = [0u8; 1];
+            transport
+                .read(&mut buf)
+                .await
+                .map_err(|_| SerprogError::TransportRead("Error reading SBustype data"))?;
+            if buf[0] == 0x08 {
+                debug!("Received SBustype 'SPI'");
+                transport
                     .write(&[S_ACK])
                     .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing ACK"))?;
-                Ok(())
-            }
-            SerprogCommand::QIface => {
-                debug!("Received QIface CMD");
-                let response = QIfaceResponse {
-                    ack: S_ACK,
-                    version: U16::new(1),
-                };
-                self.transport
-                    .write(response.as_bytes())
+                    .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
+            } else {
+                debug!("Received unknown SBustype");
+                transport
+                    .write(&[S_NAK])
                     .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QIface response"))?;
-                Ok(())
+                    .map_err(|_| SerprogError::TransportWrite("Error writing SBustype NAK"))?;
             }
-            SerprogCommand::QCmdMap => {
-                debug!("Received QCmdMap CMD");
-                let response = QCmdMapResponse::new(self.freq_callback.is_some());
-                self.transport
-                    .write(response.as_bytes())
+            Ok(())
+        }
+        SerprogCommand::OSpiOp => {
+            debug!("Received OSpiOp CMD");
+
+            // Read directly into the first channel buffer
+            let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
+            usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
+            transport
+                .read(usb_rx_spi_tx_buf[0].as_mut_slice())
+                .await
+                .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+
+            // Parse header from the first buffer
+            let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
+            let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
+
+            let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
+                Channel::new(&mut usb_rx_spi_tx_buf);
+            let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
+
+            let mut usb_tx_spi_rx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 8];
+            let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
+                Channel::new(&mut usb_tx_spi_rx_buf);
+            let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
+
+            // Acquire SPI device - pins are set to output mode
+            // When guard is dropped, pins will be set back to input mode
+            let mut spi_guard = spi_provider.acquire(*spi_freq_hz);
+            let (spi, cs) = spi_guard.spi_cs();
+
+            let (spi_res, usb_res) = block_on(join(
+                ospiop_spi_task::<_, _, TRANSFER_SIZE>(spi, spi_tx, op_slen, spi_rx, op_rlen, cs),
+                ospiop_usb_task::<_, TRANSFER_SIZE>(transport, usb_rx, op_slen, usb_tx, op_rlen),
+            ));
+
+            // Guard is dropped here, releasing the SPI pins back to input mode
+            drop(spi_guard);
+
+            if let Err(spi_err) = spi_res {
+                transport
+                    .write(&[S_NAK])
                     .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QCmdMap response"))?;
-                Ok(())
+                    .map_err(|_| SerprogError::TransportWrite("Failed to report SPI failed"))?;
+                return Err(spi_err);
             }
-            SerprogCommand::QPgmName => {
-                debug!("Received QPgmName CMD");
-                let response = QPgmNameResponse::new("Picoprog");
-                self.transport
-                    .write(response.as_bytes())
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QPgmName response"))?;
-                Ok(())
+            usb_res?;
+
+            Ok(())
+        }
+        SerprogCommand::SSpiFreq => {
+            debug!("Received SSpiFreq CMD");
+            let mut request = SSpiFreqRequest::new_zeroed();
+            transport
+                .read(request.as_mut_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportRead("Error reading SSpiFreq data"))?;
+
+            // Store the requested frequency for use when acquiring SPI
+            let requested_freq = request.freq.get();
+            *spi_freq_hz = requested_freq;
+
+            debug!("Setting SPI frequency: {:?}", requested_freq);
+
+            // Create and send response
+            let response = SSpiFreqResponse {
+                ack: S_ACK,
+                freq: U32::new(requested_freq),
+            };
+
+            transport
+                .write(response.as_bytes())
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing SSpiFreq response"))?;
+
+            Ok(())
+        }
+        SerprogCommand::SPinState => {
+            debug!("Received SPinState CMD");
+            let mut buf = [0u8; 1];
+            transport
+                .read(&mut buf)
+                .await
+                .map_err(|_| SerprogError::TransportRead("Error reading SPinState data"))?;
+            let led = led_provider.led();
+            if buf[0] == 0 {
+                led.set_low()
+                    .map_err(|_| SerprogError::LedSetLow("Error setting LED low"))?;
+            } else {
+                led.set_high()
+                    .map_err(|_| SerprogError::LedSetHigh("Error setting LED high"))?;
             }
-            SerprogCommand::QSerBuf => {
-                debug!("Received QSerBuf CMD");
-                self.transport
-                    .write(&[S_ACK, 0xFF, 0xFF])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QSerBuf response"))?;
-                Ok(())
-            }
-            SerprogCommand::QWrNMaxLen | SerprogCommand::QRdNMaxLen => {
-                debug!("Received QWrNMaxLen/QRdNMaxLen CMD");
-                let response = QMaxLenResponse::new(MAX_BUFFER_SIZE);
-                self.transport
-                    .write(response.as_bytes())
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QMaxLen response"))?;
-                Ok(())
-            }
-            SerprogCommand::QBustype => {
-                debug!("Received QBustype CMD");
-                self.transport
-                    .write(&[S_ACK, 0x08])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing QBustype response"))?;
-                Ok(())
-            }
-            SerprogCommand::SyncNop => {
-                debug!("Received SyncNop CMD");
-                self.transport
-                    .write(&[S_NAK, S_ACK])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing SyncNop response"))?;
-                Ok(())
-            }
-            SerprogCommand::SBustype => {
-                debug!("Received SBustype CMD");
-                let mut buf = [0u8; 1];
-                self.transport
-                    .read(&mut buf)
-                    .await
-                    .map_err(|_| SerprogError::TransportRead("Error reading SBustype data"))?;
-                if buf[0] == 0x08 {
-                    debug!("Received SBustype 'SPI'");
-                    self.transport
-                        .write(&[S_ACK])
-                        .await
-                        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype ACK"))?;
-                } else {
-                    debug!("Received unknown SBustype");
-                    self.transport
-                        .write(&[S_NAK])
-                        .await
-                        .map_err(|_| SerprogError::TransportWrite("Error writing SBustype NAK"))?;
-                }
-                Ok(())
-            }
-            SerprogCommand::OSpiOp => {
-                debug!("Received OSpiOp CMD");
+            transport
+                .write(&[S_ACK])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing SPinState ACK"))?;
 
-                // Read directly into the first channel buffer
-                let mut usb_rx_spi_tx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 4];
-                usb_rx_spi_tx_buf[0].resize(TRANSFER_SIZE, 0).ok();
-                self.transport
-                    .read(usb_rx_spi_tx_buf[0].as_mut_slice())
-                    .await
-                    .map_err(|_| SerprogError::TransportRead("Error reading OSpiOp data"))?;
+            Ok(())
+        }
+        _ => {
+            debug!("Received unknown CMD");
+            transport
+                .write(&[S_NAK])
+                .await
+                .map_err(|_| SerprogError::TransportWrite("Error writing unknown command NAK"))?;
 
-                // Parse header from the first buffer
-                let op_slen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][0..3]) as usize;
-                let op_rlen = le_u24_to_u32(&usb_rx_spi_tx_buf[0][3..6]) as usize;
-
-                let mut usb_rx_spi_tx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
-                    Channel::new(&mut usb_rx_spi_tx_buf);
-                let (usb_rx, spi_tx) = usb_rx_spi_tx_channel.split();
-
-                let mut usb_tx_spi_rx_buf = [const { Vec::<u8, TRANSFER_SIZE>::new() }; 8];
-                let mut usb_tx_spi_rx_channel: Channel<'_, NoopRawMutex, Vec<u8, TRANSFER_SIZE>> =
-                    Channel::new(&mut usb_tx_spi_rx_buf);
-                let (spi_rx, usb_tx) = usb_tx_spi_rx_channel.split();
-
-                let (spi_res, usb_res) = block_on(join(
-                    ospiop_spi_task::<_, _, TRANSFER_SIZE>(
-                        &mut self.spi,
-                        spi_tx,
-                        op_slen,
-                        spi_rx,
-                        op_rlen,
-                        &mut self.cs,
-                    ),
-                    ospiop_usb_task::<_, TRANSFER_SIZE>(
-                        &mut self.transport,
-                        usb_rx,
-                        op_slen,
-                        usb_tx,
-                        op_rlen,
-                    ),
-                ));
-                if let Err(spi_err) = spi_res {
-                    self.transport
-                        .write(&[S_NAK])
-                        .await
-                        .map_err(|_| SerprogError::TransportWrite("Failed to report SPI failed"))?;
-                    return Err(spi_err);
-                }
-                usb_res?;
-
-                Ok(())
-            }
-            SerprogCommand::SSpiFreq => {
-                debug!("Received SSpiFreq CMD");
-                let mut request = SSpiFreqRequest::new_zeroed();
-                self.transport
-                    .read(request.as_mut_bytes())
-                    .await
-                    .map_err(|_| SerprogError::TransportRead("Error reading SSpiFreq data"))?;
-
-                // Parse the request using zerocopy
-                let try_freq = request.freq.get();
-
-                debug!("Setting SPI frequency: {:?}", try_freq);
-
-                // Call the frequency callback if set
-                if let Some(callback) = &mut self.freq_callback {
-                    (callback)(&mut self.spi, try_freq);
-                }
-
-                // Create and send response
-                let response = SSpiFreqResponse {
-                    ack: S_ACK,
-                    freq: U32::new(try_freq), // TODO can we report what the hardware has set up?
-                };
-
-                self.transport
-                    .write(response.as_bytes())
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing SSpiFreq response"))?;
-
-                Ok(())
-            }
-            SerprogCommand::SPinState => {
-                debug!("Received SPinState CMD");
-                let mut buf = [0u8; 1];
-                self.transport
-                    .read(&mut buf)
-                    .await
-                    .map_err(|_| SerprogError::TransportRead("Error reading SPinState data"))?;
-                if buf[0] == 0 {
-                    self.led
-                        .set_low()
-                        .map_err(|_| SerprogError::LedSetLow("Error setting LED low"))?;
-                } else {
-                    self.led
-                        .set_high()
-                        .map_err(|_| SerprogError::LedSetHigh("Error setting LED high"))?;
-                }
-                self.transport
-                    .write(&[S_ACK])
-                    .await
-                    .map_err(|_| SerprogError::TransportWrite("Error writing SPinState ACK"))?;
-
-                Ok(())
-            }
-            _ => {
-                debug!("Received unknown CMD");
-                self.transport.write(&[S_NAK]).await.map_err(|_| {
-                    SerprogError::TransportWrite("Error writing unknown command NAK")
-                })?;
-
-                Ok(())
-            }
+            Ok(())
         }
     }
 }

--- a/serprog/src/transport.rs
+++ b/serprog/src/transport.rs
@@ -1,18 +1,20 @@
 use core::future;
 use embassy_usb::class::cdc_acm::CdcAcmClass;
 
-pub trait Transport {
+pub trait Transport<const TRANSFER_SIZE: usize> {
     fn read(&mut self, buf: &mut [u8]) -> impl future::Future<Output = Result<(), ()>>;
     fn write(&mut self, data: &[u8]) -> impl future::Future<Output = Result<(), ()>>;
 }
 
-impl<'d, D: embassy_usb::driver::Driver<'d>> Transport for CdcAcmClass<'d, D> {
+impl<'d, D: embassy_usb::driver::Driver<'d>, const TRANSFER_SIZE: usize> Transport<TRANSFER_SIZE>
+    for CdcAcmClass<'d, D>
+{
     async fn read(&mut self, buf: &mut [u8]) -> Result<(), ()> {
         let packet_size = self.max_packet_size() as usize;
         let buf_len = buf.len();
 
         // Use a buffer large enough for full speed and high speed
-        let mut buffer = [0; 512];
+        let mut buffer = [0; TRANSFER_SIZE];
         let mut size = 0;
         if buf_len < packet_size {
             let bytes_read = self


### PR DESCRIPTION
If the host decides to halt an operation we want to get back into a state
where we can accept further commands.